### PR TITLE
assertThrownBy() should not happen on java/jdk packages

### DIFF
--- a/client/src/main/java/org/evosuite/regression/RegressionAssertionCounter.java
+++ b/client/src/main/java/org/evosuite/regression/RegressionAssertionCounter.java
@@ -504,7 +504,8 @@ public class RegressionAssertionCounter {
 				sourceClass.startsWith(PackageInfo.getEvoSuitePackage()+".runtime.")) &&
 				!sourceClass.equals(URLClassLoader.class.getName()) && // Classloaders may differ, e.g. when running with ant
                 !sourceClass.startsWith(RegExp.class.getPackage().getName()) &&
-                !sourceClass.startsWith("java.") &&
+                !sourceClass.startsWith("java.lang.System.arraycopy") &&
+                !sourceClass.startsWith("java.lang.String") &&
                 !sourceClass.startsWith("sun.") &&
                 !sourceClass.startsWith("com.sun.") &&
                 !sourceClass.startsWith("jdk.internal.");

--- a/client/src/main/java/org/evosuite/regression/RegressionAssertionCounter.java
+++ b/client/src/main/java/org/evosuite/regression/RegressionAssertionCounter.java
@@ -504,7 +504,7 @@ public class RegressionAssertionCounter {
 				sourceClass.startsWith(PackageInfo.getEvoSuitePackage()+".runtime.")) &&
 				!sourceClass.equals(URLClassLoader.class.getName()) && // Classloaders may differ, e.g. when running with ant
                 !sourceClass.startsWith(RegExp.class.getPackage().getName()) &&
-                !sourceClass.startsWith("java.lang.System.arraycopy") &&
+                !sourceClass.startsWith("java.lang.System") &&
                 !sourceClass.startsWith("java.lang.String") &&
                 !sourceClass.startsWith("sun.") &&
                 !sourceClass.startsWith("com.sun.") &&

--- a/client/src/main/java/org/evosuite/regression/RegressionAssertionCounter.java
+++ b/client/src/main/java/org/evosuite/regression/RegressionAssertionCounter.java
@@ -503,7 +503,11 @@ public class RegressionAssertionCounter {
 		return (! sourceClass.startsWith(PackageInfo.getEvoSuitePackage()+".") ||
 				sourceClass.startsWith(PackageInfo.getEvoSuitePackage()+".runtime.")) &&
 				!sourceClass.equals(URLClassLoader.class.getName()) && // Classloaders may differ, e.g. when running with ant
-                !sourceClass.startsWith(RegExp.class.getPackage().getName());
+                !sourceClass.startsWith(RegExp.class.getPackage().getName()) &&
+                !sourceClass.startsWith("java.") &&
+                !sourceClass.startsWith("sun.") &&
+                !sourceClass.startsWith("com.sun.") &&
+                !sourceClass.startsWith("jdk.internal.");
 	}
 
 	private static List<Class<?>> invalidExceptions = Arrays.asList(new Class<?>[] {

--- a/client/src/main/java/org/evosuite/testcase/TestCodeVisitor.java
+++ b/client/src/main/java/org/evosuite/testcase/TestCodeVisitor.java
@@ -1465,7 +1465,8 @@ public class TestCodeVisitor extends TestVisitor {
 				sourceClass.startsWith(PackageInfo.getEvoSuitePackage()+".runtime.")) &&
 				!sourceClass.equals(URLClassLoader.class.getName()) && // Classloaders may differ, e.g. when running with ant
                 !sourceClass.startsWith(RegExp.class.getPackage().getName()) &&
-                !sourceClass.startsWith("java.") &&
+                !sourceClass.startsWith("java.lang.System.arraycopy") &&
+                !sourceClass.startsWith("java.lang.String") &&
                 !sourceClass.startsWith("sun.") &&
                 !sourceClass.startsWith("com.sun.") &&
                 !sourceClass.startsWith("jdk.internal.");

--- a/client/src/main/java/org/evosuite/testcase/TestCodeVisitor.java
+++ b/client/src/main/java/org/evosuite/testcase/TestCodeVisitor.java
@@ -1465,7 +1465,7 @@ public class TestCodeVisitor extends TestVisitor {
 				sourceClass.startsWith(PackageInfo.getEvoSuitePackage()+".runtime.")) &&
 				!sourceClass.equals(URLClassLoader.class.getName()) && // Classloaders may differ, e.g. when running with ant
                 !sourceClass.startsWith(RegExp.class.getPackage().getName()) &&
-                !sourceClass.startsWith("java.lang.System.arraycopy") &&
+                !sourceClass.startsWith("java.lang.System") &&
                 !sourceClass.startsWith("java.lang.String") &&
                 !sourceClass.startsWith("sun.") &&
                 !sourceClass.startsWith("com.sun.") &&

--- a/client/src/main/java/org/evosuite/testcase/TestCodeVisitor.java
+++ b/client/src/main/java/org/evosuite/testcase/TestCodeVisitor.java
@@ -1464,7 +1464,11 @@ public class TestCodeVisitor extends TestVisitor {
 		return (! sourceClass.startsWith(PackageInfo.getEvoSuitePackage()+".") ||
 				sourceClass.startsWith(PackageInfo.getEvoSuitePackage()+".runtime.")) &&
 				!sourceClass.equals(URLClassLoader.class.getName()) && // Classloaders may differ, e.g. when running with ant
-                !sourceClass.startsWith(RegExp.class.getPackage().getName());
+                !sourceClass.startsWith(RegExp.class.getPackage().getName()) &&
+                !sourceClass.startsWith("java.") &&
+                !sourceClass.startsWith("sun.") &&
+                !sourceClass.startsWith("com.sun.") &&
+                !sourceClass.startsWith("jdk.internal.");
 	}
 
 	private List<Class<?>> invalidExceptions = Arrays.asList(new Class<?>[] {


### PR DESCRIPTION
For instance, Evosuite may generate a
`assertThrownBy("java.lang.String", e);` while it can be a
`java.lang.System.arraycopy(Native Method);` , which can results in flaky tests.