### PR TITLE
Add option to skip missing output variables, without crashing

### DIFF
--- a/client/src/main/java/org/evosuite/Properties.java
+++ b/client/src/main/java/org/evosuite/Properties.java
@@ -1082,6 +1082,9 @@ public class Properties {
 
 	@Parameter(key = "new_statistics", group = "Output", description = "Use the new statistics backend on the master")
 	public static boolean NEW_STATISTICS = true;
+	
+	@Parameter(key = "ignore_missing_statistics", group = "Output", description = "Return an empty string for missing output variables")
+	public static boolean IGNORE_MISSING_STATISTICS = false;
 
 	@Parameter(key = "float_precision", group = "Output", description = "Precision to use in float comparisons and assertions")
 	public static float FLOAT_PRECISION = 0.01F;

--- a/master/src/main/java/org/evosuite/statistics/SearchStatistics.java
+++ b/master/src/main/java/org/evosuite/statistics/SearchStatistics.java
@@ -266,15 +266,23 @@ public class SearchStatistics implements Listener<ClientStateInformation>{
 		}
 		return variableNames;
 	}
+	
+	/**
+	 * Shorthand for getOutputVariables(individual, false)
+	 */
+	private Map<String, OutputVariable<?>> getOutputVariables(TestSuiteChromosome individual) {
+		return getOutputVariables(individual, false);
+	}
 
 	/**
 	 * Extract output variables from input <code>individual</code>.
 	 * Add also all the other needed search-level variables. 
 	 * 
 	 * @param individual
+	 * @param skip_missing whether or not to skip missing output variables
 	 * @return <code>null</code> if some data is missing
 	 */
-	private Map<String, OutputVariable<?>> getOutputVariables(TestSuiteChromosome individual) {
+	private Map<String, OutputVariable<?>> getOutputVariables(TestSuiteChromosome individual, boolean skip_missing) {
 		Map<String, OutputVariable<?>> variables = new LinkedHashMap<String, OutputVariable<?>>();
 		
 		for(String variableName : getOutputVariableNames()) {
@@ -295,8 +303,10 @@ public class SearchStatistics implements Listener<ClientStateInformation>{
 				for(OutputVariable<?> var : sequenceOutputVariableFactories.get(variableName).getOutputVariables()) {
 					variables.put(var.getName(), var); 
 				}
-			}
-			else {
+			} else if(skip_missing) {
+				// if variable doesn't exist, return an empty value instead
+				variables.put(variableName, new OutputVariable<String>(variableName, ""));
+			} else {
 				logger.error("No obtained value for output variable: "+variableName);
 				return null;
 			}
@@ -351,6 +361,10 @@ public class SearchStatistics implements Listener<ClientStateInformation>{
 					map = getOutputVariables(individual);
 					counter++;
 				}
+			}
+			
+			if(map == null && Properties.IGNORE_MISSING_STATISTICS){
+				map = getOutputVariables(individual, true);
 			}
 
 			if(map == null) {


### PR DESCRIPTION
Sometimes it is okay for individual output variables (in the statistics) to be missing/null, rather than not having the `statistics.csv` data at all.

For instance, in a scenario where we are running evosuite under different configurations, and in one of the configurations, a certain output variable is not produced/interesting. However, the data from different configurations would end up with different number of columns if we exclude the output variable in the runtime arguments.

This commit adds a new property `ignore_missing_statistics` which is by default `false`. Enabling it would produce empty values for output variables that we do not have values for.

I decided to make this a PR in case someone wants to have discussion on how it should work. If it looks fine, let me know and I'll merge it.