### PR TITLE
Setting the chromosome as "changed" only when needed

### DIFF
--- a/client/src/main/java/org/evosuite/testcase/TestChromosome.java
+++ b/client/src/main/java/org/evosuite/testcase/TestChromosome.java
@@ -179,14 +179,13 @@ public class TestChromosome extends ExecutableChromosome {
 		}
 		for (int i = position2; i < other.size(); i++) {
 			testFactory.appendStatement(offspring.test,
-			                            ((TestChromosome) other).test.getStatement(i));
+					((TestChromosome) other).test.getStatement(i));
 		}
 		if (!Properties.CHECK_MAX_LENGTH
-		        || offspring.test.size() <= Properties.CHROMOSOME_LENGTH) {
+				|| offspring.test.size() <= Properties.CHROMOSOME_LENGTH) {
 			test = offspring.test;
+			setChanged(true);
 		}
-
-		setChanged(true);
 	}
 
 	/**


### PR DESCRIPTION
if a test chromosome is not changed (because it 
becomes too long after crossover) it must not be
set as "changed = true". This boolean value
is used later to check whether it must be 
re-executed or not