### PR TITLE
Fix some issues for the class "StatementCoverageTestFitness"

### DIFF
--- a/client/src/main/java/org/evosuite/coverage/statement/StatementCoverageTestFitness.java
+++ b/client/src/main/java/org/evosuite/coverage/statement/StatementCoverageTestFitness.java
@@ -85,24 +85,31 @@ public class StatementCoverageTestFitness extends TestFitnessFunction {
 	public double getFitness(TestChromosome individual, ExecutionResult result) {
 
 		if (branchFitnesses.isEmpty())
-			throw new IllegalStateException(
-			        "expect to know at least one fitness for goalInstruction");
-
-		double r = Double.MAX_VALUE;
-
-		for (BranchCoverageTestFitness branchFitness : branchFitnesses) {
-			double newFitness = branchFitness.getFitness(individual, result);
-			if (newFitness == 0.0) {
-				lastCoveringFitness = branchFitness;
-				return 0.0;
-			}
-			if (newFitness < r)
-				r = newFitness;
-		}
-
-		lastCoveringFitness = null;
-
-		return r;
+            throw new IllegalStateException(
+                    "expect to know at least one fitness for goalInstruction");
+ 
+        if (result.hasTimeout() || result.hasTestException()){
+            updateIndividual(this, individual, Double.MAX_VALUE);
+            return Double.MAX_VALUE;
+        }
+        
+        double r = Double.MAX_VALUE;
+ 
+        for (BranchCoverageTestFitness branchFitness : branchFitnesses) {
+            double newFitness = branchFitness.getFitness(individual, result);
+            if (newFitness == 0.0) {
+                lastCoveringFitness = branchFitness;
+                return 0.0;
+            }
+            if (newFitness < r)
+                r = newFitness;
+        }
+ 
+        lastCoveringFitness = null;
+ 
+        updateIndividual(this, individual, r);
+        
+        return r;
 	}
 
 	/**
@@ -168,19 +175,21 @@ public class StatementCoverageTestFitness extends TestFitnessFunction {
 	}
 
 	@Override
-	public boolean equals(Object obj) {
-		if (this == obj)
-			return true;
-		if (obj == null)
-			return false;
-		if (getClass() != obj.getClass())
-			return false;
-		StatementCoverageTestFitness other = (StatementCoverageTestFitness) obj;
-		if (goalInstruction.getInstructionId() != other.goalInstruction.getInstructionId()) {
-				return false;
-		}
-		return true;
-	}
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (obj == null)
+            return false;
+        if (getClass() != obj.getClass())
+            return false;
+        StatementCoverageTestFitness other = (StatementCoverageTestFitness) obj;
+        if (this.goalInstruction == null) {
+            if (other.goalInstruction != null)
+                return false;
+        } else if (!goalInstruction.equals(other.goalInstruction))
+            return false;
+        return true;
+    }
 
 	/* (non-Javadoc)
 	 * @see org.evosuite.testcase.TestFitnessFunction#getTargetClass()

--- a/client/src/main/java/org/evosuite/ga/metaheuristics/mosa/MOSA.java
+++ b/client/src/main/java/org/evosuite/ga/metaheuristics/mosa/MOSA.java
@@ -184,7 +184,7 @@ public class MOSA<T extends Chromosome> extends AbstractMOSA<T> {
 		if (archive.containsKey(covered)){
 			int bestSize = this.archive.get(covered).size();
 			int size = solution.size();
-			if (bestSize < size)
+			if (size < bestSize)
 				this.archive.put(covered, solution);
 		} else {
 			archive.put(covered, solution);


### PR DESCRIPTION
In the method "equals" the comparison between two StatementCoverageTestFitness instances is made by checking whether they have the same "BytecodeInstruction"

In the current version,  the equality condition holds if the two statements in comparison have the same "goalInstruction.getInstructionId()". However, the ID is not unique since it indicates the position of the corresponding BytecodeInstruction inside its own method. In other words, the ID is unique inside a single target method but it is shared with BytecodeInstructions of other methods.

Therefore, the check should be done using the methods "equals" from the class "BytecodeInstruction", which checks not only the ID but also "className" and "methodName".

To test this, you just need to run EvoSuite on any class (as target) with more than one method and using statement coverage as criterion. You will see, the difference in coverage after the fix.

-----------------------

I also added few lines in the method "getFitness" to update the fitness value of the TestChromosome being evaluated (see the method "updateIndividual").
