### PR TITLE
Fix a critical bug when updating the archive

### DIFF
--- a/client/src/main/java/org/evosuite/ga/metaheuristics/mosa/MOSA.java
+++ b/client/src/main/java/org/evosuite/ga/metaheuristics/mosa/MOSA.java
@@ -184,7 +184,7 @@ public class MOSA<T extends Chromosome> extends AbstractMOSA<T> {
 		if (archive.containsKey(covered)){
 			int bestSize = this.archive.get(covered).size();
 			int size = solution.size();
-			if (bestSize < size)
+			if (size < bestSize)
 				this.archive.put(covered, solution);
 		} else {
 			archive.put(covered, solution);


### PR DESCRIPTION
The  archiving procedure was maximizing the size of the test cases instead of minimizing them. 

Thanks to this tiny (but critical) change, the size of the final test suite is dramatically reduced