### PR TITLE
Fixing a logical bug in input/output coverage

### DIFF
--- a/client/src/main/java/org/evosuite/coverage/io/input/InputCoverageTestFitness.java
+++ b/client/src/main/java/org/evosuite/coverage/io/input/InputCoverageTestFitness.java
@@ -24,7 +24,9 @@ import static org.evosuite.coverage.io.IOCoverageConstants.*;
 import org.evosuite.coverage.io.output.OutputCoverageGoal;
 import org.evosuite.testcase.TestChromosome;
 import org.evosuite.testcase.TestFitnessFunction;
+import org.evosuite.testcase.execution.ExecutionObserver;
 import org.evosuite.testcase.execution.ExecutionResult;
+import org.evosuite.testcase.execution.TestCaseExecutor;
 import org.evosuite.testcase.statements.ConstructorStatement;
 import org.evosuite.testcase.statements.EntityWithParametersStatement;
 import org.evosuite.testcase.statements.MethodStatement;
@@ -59,6 +61,20 @@ public class InputCoverageTestFitness extends TestFitnessFunction {
             throw new IllegalArgumentException("goal cannot be null");
         }
         this.goal = goal;
+        // add the observer to TestCaseExecutor if it is not included yet
+        boolean hasObserver = false;
+        TestCaseExecutor executor = TestCaseExecutor.getInstance();
+        for (ExecutionObserver ob : executor.getExecutionObservers()){
+        	if (ob instanceof  InputObserver){
+        		hasObserver = true;
+        		break;
+        	}
+        }
+        if (!hasObserver){
+        	InputObserver observer = new InputObserver();
+			executor.addObserver(observer);
+			logger.info("Added observer for input coverage");
+        }
     }
 
     /**

--- a/client/src/main/java/org/evosuite/coverage/io/output/OutputCoverageTestFitness.java
+++ b/client/src/main/java/org/evosuite/coverage/io/output/OutputCoverageTestFitness.java
@@ -21,7 +21,9 @@ package org.evosuite.coverage.io.output;
 
 import org.evosuite.testcase.TestChromosome;
 import org.evosuite.testcase.TestFitnessFunction;
+import org.evosuite.testcase.execution.ExecutionObserver;
 import org.evosuite.testcase.execution.ExecutionResult;
+import org.evosuite.testcase.execution.TestCaseExecutor;
 import org.objectweb.asm.Type;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -33,220 +35,234 @@ import java.util.*;
  */
 public class OutputCoverageTestFitness extends TestFitnessFunction {
 
-    private static final long serialVersionUID = 1383064944691491355L;
+	private static final long serialVersionUID = 1383064944691491355L;
 
-    protected static final Logger logger = LoggerFactory.getLogger(OutputCoverageTestFitness.class);
+	protected static final Logger logger = LoggerFactory.getLogger(OutputCoverageTestFitness.class);
 
-    /**
-     * Target goal
-     */
-    private final OutputCoverageGoal goal;
+	/**
+	 * Target goal
+	 */
+	private final OutputCoverageGoal goal;
 
-    /**
-     * Constructor - fitness is specific to a method
-     *
-     * @param goal the coverage goal
-     * @throws IllegalArgumentException
-     */
-    public OutputCoverageTestFitness(OutputCoverageGoal goal) throws IllegalArgumentException {
-        if (goal == null) {
-            throw new IllegalArgumentException("goal cannot be null");
-        }
-        this.goal = goal;
-    }
+	/**
+	 * Constructor - fitness is specific to a method
+	 *
+	 * @param goal the coverage goal
+	 * @throws IllegalArgumentException
+	 */
+	public OutputCoverageTestFitness(OutputCoverageGoal goal) throws IllegalArgumentException {
+		if (goal == null) {
+			throw new IllegalArgumentException("goal cannot be null");
+		}
+		this.goal = goal;
+		// add the observer to TestCaseExecutor if it is not included yet
+		boolean hasObserver = false;
+		TestCaseExecutor executor = TestCaseExecutor.getInstance();
+		for (ExecutionObserver ob : executor.getExecutionObservers()){
+			if (ob instanceof  OutputObserver){
+				hasObserver = true;
+				break;
+			}
+		}
+		if (!hasObserver){
+			OutputObserver observer = new OutputObserver();
+			executor.addObserver(observer);
+			logger.info("Added observer for output coverage");
+		}
+	}
 
-    /**
-     * <p>
-     * getClassName
-     * </p>
-     *
-     * @return a {@link java.lang.String} object.
-     */
-    public String getClassName() {
-        return goal.getClassName();
-    }
+	/**
+	 * <p>
+	 * getClassName
+	 * </p>
+	 *
+	 * @return a {@link java.lang.String} object.
+	 */
+	public String getClassName() {
+		return goal.getClassName();
+	}
 
-    /**
-     * <p>
-     * getMethod
-     * </p>
-     *
-     * @return a {@link java.lang.String} object.
-     */
-    public String getMethod() {
-        return goal.getMethodName();
-    }
+	/**
+	 * <p>
+	 * getMethod
+	 * </p>
+	 *
+	 * @return a {@link java.lang.String} object.
+	 */
+	public String getMethod() {
+		return goal.getMethodName();
+	}
 
-    /**
-     * <p>
-     * getValue
-     * </p>
-     *
-     * @return a {@link java.lang.String} object.
-     */
-    public Type getType() {
-        return goal.getType();
-    }
+	/**
+	 * <p>
+	 * getValue
+	 * </p>
+	 *
+	 * @return a {@link java.lang.String} object.
+	 */
+	public Type getType() {
+		return goal.getType();
+	}
 
-    /**
-     * <p>
-     * getValue
-     * </p>
-     *
-     * @return a {@link java.lang.String} object.
-     */
-    public String getValueDescriptor() {
-        return goal.getValueDescriptor();
-    }
+	/**
+	 * <p>
+	 * getValue
+	 * </p>
+	 *
+	 * @return a {@link java.lang.String} object.
+	 */
+	public String getValueDescriptor() {
+		return goal.getValueDescriptor();
+	}
 
-    /**
-     * {@inheritDoc}
-     * <p/>
-     * Calculate fitness
-     *
-     * @param individual a {@link org.evosuite.testcase.ExecutableChromosome} object.
-     * @param result     a {@link org.evosuite.testcase.execution.ExecutionResult} object.
-     * @return a double.
-     */
-    @Override
-    public double getFitness(TestChromosome individual, ExecutionResult result) {
-        double fitness = 1.0;
+	/**
+	 * {@inheritDoc}
+	 * <p/>
+	 * Calculate fitness
+	 *
+	 * @param individual a {@link org.evosuite.testcase.ExecutableChromosome} object.
+	 * @param result     a {@link org.evosuite.testcase.execution.ExecutionResult} object.
+	 * @return a double.
+	 */
+	@Override
+	public double getFitness(TestChromosome individual, ExecutionResult result) {
+		double fitness = 1.0;
 
-        for(Set<OutputCoverageGoal> coveredGoals : result.getOutputGoals().values()) {
-            if(coveredGoals.contains(goal)) {
-                fitness = 0.0;
-                break;
-            }
-        }
-        updateIndividual(this, individual, fitness);
-        return fitness;
-    }
+		for(Set<OutputCoverageGoal> coveredGoals : result.getOutputGoals().values()) {
+			if(coveredGoals.contains(goal)) {
+				fitness = 0.0;
+				break;
+			}
+		}
+		updateIndividual(this, individual, fitness);
+		return fitness;
+	}
 
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public String toString() {
-        return "[Output]: "+goal.toString();
-    }
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	public String toString() {
+		return "[Output]: "+goal.toString();
+	}
 
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public int hashCode() {
-        int iConst = 13;
-        return 51 * iConst + goal.hashCode();
-    }
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	public int hashCode() {
+		int iConst = 13;
+		return 51 * iConst + goal.hashCode();
+	}
 
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public boolean equals(Object obj) {
-        if (this == obj)
-            return true;
-        if (obj == null)
-            return false;
-        if (getClass() != obj.getClass())
-            return false;
-        OutputCoverageTestFitness other = (OutputCoverageTestFitness) obj;
-        return this.goal.equals(other.goal);
-    }
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj)
+			return true;
+		if (obj == null)
+			return false;
+		if (getClass() != obj.getClass())
+			return false;
+		OutputCoverageTestFitness other = (OutputCoverageTestFitness) obj;
+		return this.goal.equals(other.goal);
+	}
 
-    /* (non-Javadoc)
-     * @see org.evosuite.testcase.TestFitnessFunction#compareTo(org.evosuite.testcase.TestFitnessFunction)
-     */
-    @Override
-    public int compareTo(TestFitnessFunction other) {
-        if (other instanceof OutputCoverageTestFitness) {
-            OutputCoverageTestFitness otherOutputFitness = (OutputCoverageTestFitness) other;
-            return goal.compareTo(otherOutputFitness.goal);
-        }
-        return compareClassName(other);
-    }
+	/* (non-Javadoc)
+	 * @see org.evosuite.testcase.TestFitnessFunction#compareTo(org.evosuite.testcase.TestFitnessFunction)
+	 */
+	@Override
+	public int compareTo(TestFitnessFunction other) {
+		if (other instanceof OutputCoverageTestFitness) {
+			OutputCoverageTestFitness otherOutputFitness = (OutputCoverageTestFitness) other;
+			return goal.compareTo(otherOutputFitness.goal);
+		}
+		return compareClassName(other);
+	}
 
-    /* (non-Javadoc)
-     * @see org.evosuite.testcase.TestFitnessFunction#getTargetClass()
-     */
-    @Override
-    public String getTargetClass() {
-        return getClassName();
-    }
+	/* (non-Javadoc)
+	 * @see org.evosuite.testcase.TestFitnessFunction#getTargetClass()
+	 */
+	@Override
+	public String getTargetClass() {
+		return getClassName();
+	}
 
-    /* (non-Javadoc)
-     * @see org.evosuite.testcase.TestFitnessFunction#getTargetMethod()
-     */
-    @Override
-    public String getTargetMethod() {
-        return getMethod();
-    }
+	/* (non-Javadoc)
+	 * @see org.evosuite.testcase.TestFitnessFunction#getTargetMethod()
+	 */
+	@Override
+	public String getTargetMethod() {
+		return getMethod();
+	}
 
-    /*
-     * TODO: Move somewhere else into a utility class
-     */
-    private static final Class<?> getClassForName(String type)
-    {
-        try
-        {
-            if( type.equals("boolean"))
-            {
-                return Boolean.TYPE;
-            }
-            else if(type.equals("byte"))
-            {
-                return Byte.TYPE;
-            }
-            else if( type.equals("char"))
-            {
-                return Character.TYPE;
-            }
-            else if( type.equals("double"))
-            {
-                return Double.TYPE;
-            }
-            else if(type.equals("float"))
-            {
-                return Float.TYPE;
-            }
-            else if(type.equals("int"))
-            {
-                return Integer.TYPE;
-            }
-            else if( type.equals("long"))
-            {
-                return Long.TYPE;
-            }
-            else if(type.equals("short"))
-            {
-                return Short.TYPE;
-            }
-            else if(type.equals("String") ||type.equals("Boolean") || type.equals("Short") ||type.equals("Long") ||
-                    type.equals("Integer") || type.equals("Float") || type.equals("Double") ||type.equals("Byte") ||
-                    type.equals("Character") )
-            {
-                return Class.forName("java.lang." + type);
-            }
+	/*
+	 * TODO: Move somewhere else into a utility class
+	 */
+	private static final Class<?> getClassForName(String type)
+	{
+		try
+		{
+			if( type.equals("boolean"))
+			{
+				return Boolean.TYPE;
+			}
+			else if(type.equals("byte"))
+			{
+				return Byte.TYPE;
+			}
+			else if( type.equals("char"))
+			{
+				return Character.TYPE;
+			}
+			else if( type.equals("double"))
+			{
+				return Double.TYPE;
+			}
+			else if(type.equals("float"))
+			{
+				return Float.TYPE;
+			}
+			else if(type.equals("int"))
+			{
+				return Integer.TYPE;
+			}
+			else if( type.equals("long"))
+			{
+				return Long.TYPE;
+			}
+			else if(type.equals("short"))
+			{
+				return Short.TYPE;
+			}
+			else if(type.equals("String") ||type.equals("Boolean") || type.equals("Short") ||type.equals("Long") ||
+					type.equals("Integer") || type.equals("Float") || type.equals("Double") ||type.equals("Byte") ||
+					type.equals("Character") )
+			{
+				return Class.forName("java.lang." + type);
+			}
 
-//			if(type.endsWith(";") && ! type.startsWith("["))
-//			{
-//				type = type.replaceFirst("L", "");
-//				type = type.replace(";", "");
-//			}
+			//			if(type.endsWith(";") && ! type.startsWith("["))
+			//			{
+			//				type = type.replaceFirst("L", "");
+			//				type = type.replace(";", "");
+			//			}
 
-            if(type.endsWith("[]"))
-            {
-                type = type.replace("[]", "");
-                return Class.forName("[L" + type + ";");
-            }
-            else
-            {
-                return Class.forName(type);
-            }
-        }
-        catch (final ClassNotFoundException e)
-        {
-            throw new RuntimeException(e);
-        }
-    }
+			if(type.endsWith("[]"))
+			{
+				type = type.replace("[]", "");
+				return Class.forName("[L" + type + ";");
+			}
+			else
+			{
+				return Class.forName(type);
+			}
+		}
+		catch (final ClassNotFoundException e)
+		{
+			throw new RuntimeException(e);
+		}
+	}
 }


### PR DESCRIPTION
When working at test case level (e.g., with MOSA), the two criteria "input" and "output" coverage do not work properly. This is due to the fact that the Input/Output Observers are not added to the "TestCaseExecutor" when instantiating objects of the classes "InputCoverageTestFitness" and "OutputCoverageTestFitness". Instead, the constructors for the classes "OutputCoverageSuiteFitness" and "InputCoverageSuiteFitness" automatically add the corresponding observers to the test executor (i.e., when working at Suite level). As a consequence, these criteria are not really "considered" when running EvoSuite at test case level (e.g., with MOSA).

To test this scenario, simply run EvoSuite with the following parameters: 
"-generateMOSuite -Dcriterion=INPUT:OUTPUT -Dalgorithm=MOSA"
You will see that whatever class you select as CUT, input and output coverage is always 0%

This pull request contains the code to fix these issues.

