### PR TITLE
Fixing a NPE in Input Coverage (Suite level)

### DIFF
--- a/client/src/main/java/org/evosuite/coverage/io/input/InputCoverageSuiteFitness.java
+++ b/client/src/main/java/org/evosuite/coverage/io/input/InputCoverageSuiteFitness.java
@@ -194,6 +194,8 @@ public class InputCoverageSuiteFitness extends TestSuiteFitnessFunction {
                             updateDistances(suite, mapDistances, className, methodName, goal.getArgIndex(), argType, value);
                             break;
                         case Type.CHAR:
+                        	if (argValue == null)
+                        		continue;
                             char charValue = (char)((Number) argValue).intValue();
                             updateCharDistances(suite, mapDistances, className, methodName, goal.getArgIndex(), argType, charValue);
                             break;


### PR DESCRIPTION
EvoSuite crashes generating the following NullPointerException:

java.lang.NullPointerException: null
	at org.evosuite.coverage.io.input.InputCoverageSuiteFitness.computeDistance(InputCoverageSuiteFitness.java:197) ~[classes/:na]
	at org.evosuite.coverage.io.input.InputCoverageSuiteFitness.getFitness(InputCoverageSuiteFitness.java:130) ~[classes/:na]
	at org.evosuite.coverage.io.input.InputCoverageSuiteFitness.getFitness(InputCoverageSuiteFitness.java:1) ~[classes/:na]
	at org.evosuite.ga.metaheuristics.GeneticAlgorithm.calculateFitnessAndSortPopulation(GeneticAlgorithm.java:595) ~[classes/:na]
	at org.evosuite.ga.metaheuristics.MonotonicGA.initializePopulation(MonotonicGA.java:206) ~[classes/:na]
	at org.evosuite.ga.metaheuristics.MonotonicGA.generateSolution(MonotonicGA.java:223) ~[classes/:na]
	at org.evosuite.strategy.WholeTestSuiteStrategy.generateTests(WholeTestSuiteStrategy.java:113) ~[classes/:na]
	at org.evosuite.TestSuiteGenerator.generateTests(TestSuiteGenerator.java:653) ~[classes/:na]
	at org.evosuite.TestSuiteGenerator.generateTestSuite(TestSuiteGenerator.java:236) ~[classes/:na]
	at org.evosuite.rmi.service.ClientNodeImpl$1.run(ClientNodeImpl.java:145) ~[classes/:na]
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511) [na:1.8.0_102]
	at java.util.concurrent.FutureTask.run(FutureTask.java:266) [na:1.8.0_102]
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142) [na:1.8.0_102]
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617) [na:1.8.0_102]
	at java.lang.Thread.run(Thread.java:745) [na:1.8.0_102]

This happens when running EvoSuite using one of the following classes:
   - wheel.asm.ClassWriter from the project 80_wheelwebtool  (SF110 corpus)
   - org.databene.jdbacl.DBUtil from the project 13_jdbacl (SF110 corpus)
   - org.apache.commons.lang3.ClassUtils from the apache commons lang v.3.3.2

and when using the Whole Suite approach (param. "-generateSuite") with "INPUT" as one of the criteria to optimize (e.g., with param. "-Dcriterion=INPUT").

This pull request contains a simple fix to avoid the exception