### PR TITLE
Enabling the criterion "EXCEPTION" in MOSA

### DIFF
--- a/client/src/main/java/org/evosuite/strategy/MOSuiteStrategy.java
+++ b/client/src/main/java/org/evosuite/strategy/MOSuiteStrategy.java
@@ -98,8 +98,7 @@ public class MOSuiteStrategy extends TestGenerationStrategy {
 			ExecutionTracer.enableTraceCalls();
 
 		algorithm.resetStoppingConditions();
-
-		ClientServices.getInstance().getClientNode().trackOutputVariable(RuntimeVariable.Total_Goals, fitnessFunctions.size());
+		
 		TestSuiteChromosome testSuite = null;
 
 		if (!(Properties.STOP_ZERO && fitnessFunctions.isEmpty()) || ArrayUtil.contains(Properties.CRITERION, Criterion.EXCEPTION)) {
@@ -145,6 +144,12 @@ public class MOSuiteStrategy extends TestGenerationStrategy {
 		// Search is finished, send statistics
 		sendExecutionStatistics();
 
+		// We send the info about the total number of coverage goals/targets only after 
+		// the end of the search. This is because the number of coverage targets may vary
+		// when the criterion Properties.Criterion.EXCEPTION is used (exception coverage
+		// goal are dynamically added when the generated tests trigger some exceptions
+		ClientServices.getInstance().getClientNode().trackOutputVariable(RuntimeVariable.Total_Goals, algorithm.getFitnessFunctions().size());
+		
 		return testSuite;
 	}
 	


### PR DESCRIPTION
Looking at the "exception coverage" I found out that it does not work for MOSA. For what I understood, it is completely different from the other coverage criteria since the number of exceptions thrown by generated tests cannot be known a priori. Thus, the list of ExceptionCoverageTestFitness produced by ExceptionCoverageFactory is empty the the beginning of the search. As a consequence, when running MOSA, the list of ExceptionCoverageTestFitness is empty and this criterion is therefore ignored in practice.

To enable  this criterion with MOSA, in this pull request I have added a new method in AbstractMOSA to analyze the results of test execution and to keep track of the covered exceptions when EvoSuite is executed with "EXCEPTION" as criterion in addition to other (more standard) criteria (e.g., branch coverage)