### PR TITLE
Windows and Linux child process should be started by java binary file absolute path, not just "java" command

### DIFF
--- a/master/src/main/java/org/evosuite/EvoSuite.java
+++ b/master/src/main/java/org/evosuite/EvoSuite.java
@@ -46,6 +46,7 @@ import org.evosuite.executionmode.Setup;
 import org.evosuite.executionmode.TestGeneration;
 import org.evosuite.junit.writer.TestSuiteWriterUtils;
 import org.evosuite.runtime.sandbox.MSecurityManager;
+import org.evosuite.runtime.util.JavaExecCmdUtil;
 import org.evosuite.setup.InheritanceTree;
 import org.evosuite.setup.InheritanceTreeGenerator;
 import org.evosuite.utils.LoggingUtils;
@@ -70,13 +71,14 @@ public class EvoSuite {
     private static Logger logger = LoggerFactory.getLogger(EvoSuite.class);
 
     private static String separator = System.getProperty("file.separator");
-    private static String javaHome = System.getProperty("java.home");
+    //private static String javaHome = System.getProperty("java.home");
 
     /**
+     * Functional moved to @{@link JavaExecCmdUtil#getJavaBinExecutablePath()}
      * Constant
      * <code>JAVA_CMD="javaHome + separator + bin + separatorj"{trunked}</code>
      */
-    public final static String JAVA_CMD = javaHome + separator + "bin" + separator + "java";
+    //public final static String JAVA_CMD = javaHome + separator + "bin" + separator + "java";
 
     public static String base_dir_path = System.getProperty("user.dir");
 

--- a/master/src/main/java/org/evosuite/continuous/job/JobHandler.java
+++ b/master/src/main/java/org/evosuite/continuous/job/JobHandler.java
@@ -32,6 +32,7 @@ import org.evosuite.classpath.ClassPathHandler;
 import org.evosuite.continuous.persistency.StorageManager;
 import org.evosuite.coverage.CoverageCriteriaAnalyzer;
 import org.evosuite.runtime.util.JarPathing;
+import org.evosuite.runtime.util.JavaExecCmdUtil;
 import org.evosuite.statistics.RuntimeVariable;
 import org.evosuite.utils.LoggingUtils;
 import org.slf4j.Logger;
@@ -205,7 +206,7 @@ public class JobHandler extends Thread {
 	private List<String> getCommandString(JobDefinition job) {
 
 		List<String> commands = new ArrayList<>();
-		commands.add("java");		
+		commands.add(JavaExecCmdUtil.getJavaBinExecutablePath()/*"java"*/);
 
 		commands.add("-cp");
 		commands.add(configureAndGetClasspath());

--- a/master/src/main/java/org/evosuite/executionmode/MeasureCoverage.java
+++ b/master/src/main/java/org/evosuite/executionmode/MeasureCoverage.java
@@ -36,6 +36,7 @@ import org.evosuite.classpath.ResourceList;
 import org.evosuite.instrumentation.BytecodeInstrumentation;
 import org.evosuite.rmi.MasterServices;
 import org.evosuite.rmi.service.ClientNodeRemote;
+import org.evosuite.runtime.util.JavaExecCmdUtil;
 import org.evosuite.statistics.SearchStatistics;
 import org.evosuite.utils.ExternalProcessHandler;
 import org.evosuite.utils.LoggingUtils;
@@ -100,7 +101,7 @@ public class MeasureCoverage {
 		ExternalProcessHandler handler = new ExternalProcessHandler();
 		int port = handler.openServer();
 		List<String> cmdLine = new ArrayList<String>();
-		cmdLine.add(EvoSuite.JAVA_CMD);
+		cmdLine.add(JavaExecCmdUtil.getJavaBinExecutablePath(true)/*EvoSuite.JAVA_CMD*/);
 		cmdLine.add("-cp");
 		cmdLine.add(classPath);
 		cmdLine.add("-Dprocess_communication_port=" + port);

--- a/master/src/main/java/org/evosuite/executionmode/PrintStats.java
+++ b/master/src/main/java/org/evosuite/executionmode/PrintStats.java
@@ -37,6 +37,7 @@ import org.evosuite.classpath.ClassPathHandler;
 import org.evosuite.instrumentation.BytecodeInstrumentation;
 import org.evosuite.rmi.MasterServices;
 import org.evosuite.rmi.service.ClientNodeRemote;
+import org.evosuite.runtime.util.JavaExecCmdUtil;
 import org.evosuite.utils.ExternalProcessHandler;
 import org.evosuite.utils.LoggingUtils;
 import org.slf4j.Logger;
@@ -77,7 +78,7 @@ public class PrintStats {
 		ExternalProcessHandler handler = new ExternalProcessHandler();
 		int port = handler.openServer();
 		List<String> cmdLine = new ArrayList<String>();
-		cmdLine.add(EvoSuite.JAVA_CMD);
+		cmdLine.add(JavaExecCmdUtil.getJavaBinExecutablePath(true)/*EvoSuite.JAVA_CMD*/);
 		cmdLine.add("-cp");
 		cmdLine.add(classPath);
 		cmdLine.add("-Dprocess_communication_port=" + port);

--- a/master/src/main/java/org/evosuite/executionmode/TestGeneration.java
+++ b/master/src/main/java/org/evosuite/executionmode/TestGeneration.java
@@ -35,6 +35,7 @@ import org.evosuite.result.TestGenerationResultBuilder;
 import org.evosuite.rmi.MasterServices;
 import org.evosuite.rmi.service.ClientNodeRemote;
 import org.evosuite.runtime.util.JarPathing;
+import org.evosuite.runtime.util.JavaExecCmdUtil;
 import org.evosuite.statistics.SearchStatistics;
 import org.evosuite.utils.ExternalProcessHandler;
 import org.evosuite.utils.LoggingUtils;
@@ -221,7 +222,7 @@ public class TestGeneration {
 		}
 
 		List<String> cmdLine = new ArrayList<>();
-		cmdLine.add(EvoSuite.JAVA_CMD);
+		cmdLine.add(JavaExecCmdUtil.getJavaBinExecutablePath(true)/*EvoSuite.JAVA_CMD*/);
 
 		handleClassPath(cmdLine);
 

--- a/master/src/main/java/org/evosuite/executionmode/WriteDependencies.java
+++ b/master/src/main/java/org/evosuite/executionmode/WriteDependencies.java
@@ -37,6 +37,7 @@ import org.evosuite.classpath.ClassPathHandler;
 import org.evosuite.instrumentation.BytecodeInstrumentation;
 import org.evosuite.rmi.MasterServices;
 import org.evosuite.rmi.service.ClientNodeRemote;
+import org.evosuite.runtime.util.JavaExecCmdUtil;
 import org.evosuite.utils.ExternalProcessHandler;
 import org.evosuite.utils.LoggingUtils;
 import org.slf4j.Logger;
@@ -78,7 +79,7 @@ public class WriteDependencies {
 		ExternalProcessHandler handler = new ExternalProcessHandler();
 		int port = handler.openServer();
 		List<String> cmdLine = new ArrayList<String>();
-		cmdLine.add(EvoSuite.JAVA_CMD);
+		cmdLine.add(JavaExecCmdUtil.getJavaBinExecutablePath(true)/*EvoSuite.JAVA_CMD*/);
 		cmdLine.add("-cp");
 		cmdLine.add(classPath);
 		cmdLine.add("-Dprocess_communication_port=" + port);

--- a/plugins/maven/src/main/java/org/evosuite/maven/util/EvoSuiteRunner.java
+++ b/plugins/maven/src/main/java/org/evosuite/maven/util/EvoSuiteRunner.java
@@ -38,6 +38,7 @@ import org.apache.maven.project.ProjectBuildingException;
 import org.apache.maven.project.ProjectBuildingResult;
 import org.eclipse.aether.RepositorySystemSession;
 import org.evosuite.EvoSuite;
+import org.evosuite.runtime.util.JavaExecCmdUtil;
 import org.evosuite.utils.LoggingUtils;
 
 /**
@@ -168,7 +169,7 @@ public class EvoSuiteRunner {
 		String entryPoint = EvoSuite.class.getName();
 		
 		List<String> cmd = new ArrayList<>();
-		cmd.add("java");
+		cmd.add(JavaExecCmdUtil.getJavaBinExecutablePath()/*"java"*/);
 		cmd.add("-D" + LoggingUtils.USE_DIFFERENT_LOGGING_XML_PARAMETER + "=logback-ctg-entry.xml");
 		cmd.add("-Dlogback.configurationFile=logback-ctg-entry.xml");
 		cmd.add("-cp");
@@ -238,7 +239,7 @@ public class EvoSuiteRunner {
 		logger.info("Going to use EvoSuite jar: "+evo);
 
 		List<String> cmd = new ArrayList<>();
-		cmd.add("java");
+		cmd.add(JavaExecCmdUtil.getJavaBinExecutablePath()/*"java"*/);
 		cmd.add("-jar");
 		cmd.add(""+evo);
 		return cmd;

--- a/pom.xml
+++ b/pom.xml
@@ -432,7 +432,11 @@
                 <version>1.10.1</version>
                 <scope>provided</scope>
             </dependency>
-
+            <dependency>
+                <groupId>com.github.stefanbirkner</groupId>
+                <artifactId>system-rules</artifactId>
+                <version>1.16.0</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 

--- a/runtime/pom.xml
+++ b/runtime/pom.xml
@@ -127,7 +127,11 @@
             <groupId>org.ow2.asm</groupId>
             <artifactId>asm-all</artifactId>
         </dependency>
-
+        <dependency>
+            <groupId>com.github.stefanbirkner</groupId>
+            <artifactId>system-rules</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
 </project>

--- a/runtime/src/main/java/org/evosuite/runtime/util/JavaExecCmdUtil.java
+++ b/runtime/src/main/java/org/evosuite/runtime/util/JavaExecCmdUtil.java
@@ -1,0 +1,62 @@
+package org.evosuite.runtime.util;
+
+import java.io.File;
+import java.util.Optional;
+
+/**
+ * Created by wildfly.ua@gmail.com for EvoSuite project (https://github.com/EvoSuite/evosuite)
+ */
+public class JavaExecCmdUtil {
+
+  /**
+   * Utility class, no public constructors
+   */
+  private JavaExecCmdUtil() {
+  }
+
+  /**
+   * There is java environment configuration gap - ${JAVA_HOME}/bin/java != `which java` so just
+   * start child process as "java" executable command drives to unexpected results. On generic Lunix
+   * environment 'which java' may show not Oracle hotspot 8th jdk binary and evoSuite
+   * master<->client communication will have no results.
+   *
+   * @param isFullOriginalJavaExecRequired - original behavior switch: "java" or JAVA_CMD from
+   * (@link org.evosuite.EvoSuite#JAVA_CMD)
+   * @return current runtime java executable path based on $JAVA_HOME environment variable
+   * @apiNote under maven java.home property is ${JAVA_HOME}/jre/bin/java
+   */
+  public static String getJavaBinExecutablePath(final boolean isFullOriginalJavaExecRequired) {
+    final String separator = System.getProperty("file.separator");
+    final String JAVA_CMD =
+        System.getProperty("java.home") + separator + "bin" + separator + "java";
+
+    return getJavaHomeEnv()
+        .map(javaHomeEnvVar ->
+            new File(
+                javaHomeEnvVar + File.separatorChar + "bin" + File.separatorChar + "java" +
+                    getOsName()
+                        .filter(osName -> osName.toLowerCase().contains("windows"))
+                        .map(osName -> ".exe")
+                        .orElse("")
+            )
+        )
+        .filter(File::exists)
+        .map(File::getPath)
+        .orElse(isFullOriginalJavaExecRequired ? JAVA_CMD : "java");
+  }
+
+  /**
+   * @see #getJavaBinExecutablePath(boolean)
+   */
+  public static String getJavaBinExecutablePath() {
+    return getJavaBinExecutablePath(false);
+  }
+
+  private static Optional<String> getJavaHomeEnv() {
+    return Optional.ofNullable(System.getenv("JAVA_HOME"));
+  }
+
+  static Optional<String> getOsName() {
+    return Optional.ofNullable(System.getProperty("os.name"));
+  }
+}

--- a/runtime/src/test/java/org/evosuite/runtime/util/JavaExecCmdUtilUnixTest.java
+++ b/runtime/src/test/java/org/evosuite/runtime/util/JavaExecCmdUtilUnixTest.java
@@ -1,0 +1,90 @@
+package org.evosuite.runtime.util;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThat;
+
+import org.hamcrest.core.IsEqual;
+import org.junit.Before;
+import org.junit.FixMethodOrder;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.contrib.java.lang.system.EnvironmentVariables;
+import org.junit.contrib.java.lang.system.RestoreSystemProperties;
+import org.junit.runners.MethodSorters;
+import org.springframework.util.StringUtils;
+
+@FixMethodOrder(MethodSorters.NAME_ASCENDING)
+public class JavaExecCmdUtilUnixTest {
+
+  private static final String SEPARATOR = "/";
+  private static final String JAVA_HOME_SYSTEM = System.getenv("JAVA_HOME");
+  private static final String JAVA_HOME_MOCK_PATH =
+      SEPARATOR + "usr" + SEPARATOR + "home" + SEPARATOR + "jdk_8";
+  private static final String MOCK_OS = "Mac OS X";
+
+  @Rule
+  public EnvironmentVariables environmentVariables = new EnvironmentVariables();
+
+  @Rule
+  public final RestoreSystemProperties restoreSystemProperties = new RestoreSystemProperties();
+
+  @Before
+  public void initTestEnvironment() {
+    environmentVariables.set("JAVA_HOME", JAVA_HOME_MOCK_PATH);
+  }
+
+  @Test
+  public void unixNeverNull() {
+    assertNotNull(JavaExecCmdUtil.getJavaBinExecutablePath());
+    assertNotNull(JavaExecCmdUtil.getJavaBinExecutablePath(true));
+    assertNotNull(JavaExecCmdUtil.getJavaBinExecutablePath(false));
+  }
+
+  @Test
+  public void unixMockEnvIsOk() {
+    System.setProperty("os.name", MOCK_OS);
+    System.setProperty("file.separator", SEPARATOR);
+    System.setProperty("java.home", JAVA_HOME_MOCK_PATH);
+
+    assertThat(System.getenv("JAVA_HOME"), IsEqual.equalTo(JAVA_HOME_MOCK_PATH));
+    assertThat(System.getProperty("os.name"), IsEqual.equalTo(MOCK_OS));
+    assertFalse(StringUtils.isEmpty(JAVA_HOME_SYSTEM));
+  }
+
+  @Test
+  public void unixOldBehaviorJava() {
+    // return "java" value
+    assertThat(JavaExecCmdUtil.getJavaBinExecutablePath(), IsEqual.equalTo("java"));
+  }
+
+  @Test
+  public void unixOldBehaviorJavaCmd() {
+    System.setProperty("os.name", MOCK_OS);
+    System.setProperty("file.separator", SEPARATOR);
+    System.setProperty("java.home", JAVA_HOME_MOCK_PATH);
+
+    // return JAVA_CMD value
+    assertThat(JavaExecCmdUtil.getJavaBinExecutablePath(true),
+        IsEqual.equalTo(
+            JAVA_HOME_MOCK_PATH + SEPARATOR + "bin" + SEPARATOR + "java"));
+  }
+
+  @Test
+  public void unixNewBehavior() {
+        // run test only on unix build
+            JavaExecCmdUtil.getOsName().filter(osName -> !osName.startsWith("Windows"))
+        .ifPresent(os ->
+            {
+              System.setProperty("os.name", MOCK_OS);
+              System.setProperty("file.separator", SEPARATOR);
+              System.setProperty("java.home", JAVA_HOME_MOCK_PATH);
+
+              // set correct java_home and get real path to java
+              environmentVariables.set("JAVA_HOME", JAVA_HOME_SYSTEM);
+              assertThat(JavaExecCmdUtil.getJavaBinExecutablePath(),
+                  IsEqual.equalTo(JAVA_HOME_SYSTEM + SEPARATOR + "bin" + SEPARATOR + "java"));
+            }
+        );
+  }
+}

--- a/runtime/src/test/java/org/evosuite/runtime/util/JavaExecCmdUtilWinSystemTest.java
+++ b/runtime/src/test/java/org/evosuite/runtime/util/JavaExecCmdUtilWinSystemTest.java
@@ -1,0 +1,81 @@
+package org.evosuite.runtime.util;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThat;
+
+import org.hamcrest.core.IsEqual;
+import org.junit.Before;
+import org.junit.FixMethodOrder;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.contrib.java.lang.system.EnvironmentVariables;
+import org.junit.contrib.java.lang.system.ProvideSystemProperty;
+import org.junit.runners.MethodSorters;
+import org.springframework.util.StringUtils;
+
+@FixMethodOrder(MethodSorters.NAME_ASCENDING)
+public class JavaExecCmdUtilWinSystemTest {
+
+  private static final String SEPARATOR = "\\";
+  private static final String JAVA_HOME_SYSTEM = System.getenv("JAVA_HOME");
+  private static final String JAVA_HOME_MOCK_PATH =
+      "c:" + SEPARATOR + "sample" + SEPARATOR + "windows path" + SEPARATOR + "jdk_8";
+  private static final String WIN_MOCK_OS = "Windows 10";
+
+  @Rule
+  public EnvironmentVariables environmentVariables = new EnvironmentVariables();
+
+  @Rule
+  public final ProvideSystemProperty properties =
+      new ProvideSystemProperty("os.name", WIN_MOCK_OS)
+          .and("file.separator", SEPARATOR)
+          .and("java.home", JAVA_HOME_MOCK_PATH);
+
+  @Before
+  public void initTestEnvironment() {
+    environmentVariables.set("JAVA_HOME", JAVA_HOME_MOCK_PATH);
+  }
+
+  @Test
+  public void winNeverNull() {
+    assertNotNull(JavaExecCmdUtil.getJavaBinExecutablePath());
+    assertNotNull(JavaExecCmdUtil.getJavaBinExecutablePath(true));
+    assertNotNull(JavaExecCmdUtil.getJavaBinExecutablePath(false));
+  }
+
+  @Test
+  public void winMockEnvIsOk() {
+    assertThat(System.getenv("JAVA_HOME"), IsEqual.equalTo(JAVA_HOME_MOCK_PATH));
+    assertThat(System.getProperty("os.name"), IsEqual.equalTo(WIN_MOCK_OS));
+    assertFalse(StringUtils.isEmpty(JAVA_HOME_SYSTEM));
+  }
+
+  @Test
+  public void winOldBehaviorJava() {
+    // return "java" value
+    assertThat(JavaExecCmdUtil.getJavaBinExecutablePath(), IsEqual.equalTo("java"));
+  }
+
+  @Test
+  public void winOldBehaviorJavaCmd() {
+    // return JAVA_CMD value
+    assertThat(JavaExecCmdUtil.getJavaBinExecutablePath(true),
+        IsEqual.equalTo(
+            JAVA_HOME_MOCK_PATH + SEPARATOR + "bin" + SEPARATOR + "java"));
+  }
+
+  @Test
+  public void winNewBehavior() {
+    // run test only on windows build
+    JavaExecCmdUtil.getOsName().filter(osName -> osName.startsWith("Windows")).ifPresent(os ->
+        {
+          // set correct java_home and get real path to java.exe
+          environmentVariables.set("JAVA_HOME", JAVA_HOME_SYSTEM);
+          assertThat(JavaExecCmdUtil.getJavaBinExecutablePath(),
+              IsEqual.equalTo(
+                  JAVA_HOME_SYSTEM + SEPARATOR + "bin" + SEPARATOR + "java.exe"));
+        }
+    );
+  }
+}


### PR DESCRIPTION
Linux (RedHat Ent 7.3) have different ${JAVA_HOME}/bin/java and `which java`, so maven process started with expected ${JAVA_HOME}/bin/java jvm binary, but all child process created by 'java xxxx' commands are controlled by NOT hotspot JDK java binary. And as a result there are no results(generated tests at all). This patch is fixing mentioned problem by controlling all child java process start - all of them is started by ${JAVA_HOME}/bin/java or ${JAVA_HOME}/bin/java.exe (automatically detected in runtime).