### PR TITLE
MOSA's overall coverage

### DIFF
--- a/client/src/main/java/org/evosuite/coverage/FitnessFunctions.java
+++ b/client/src/main/java/org/evosuite/coverage/FitnessFunctions.java
@@ -25,34 +25,62 @@ import org.evosuite.coverage.ambiguity.AmbiguityCoverageFactory;
 import org.evosuite.coverage.ambiguity.AmbiguityCoverageSuiteFitness;
 import org.evosuite.coverage.branch.BranchCoverageFactory;
 import org.evosuite.coverage.branch.BranchCoverageSuiteFitness;
+import org.evosuite.coverage.branch.BranchCoverageTestFitness;
 import org.evosuite.coverage.branch.OnlyBranchCoverageFactory;
 import org.evosuite.coverage.branch.OnlyBranchCoverageSuiteFitness;
+import org.evosuite.coverage.branch.OnlyBranchCoverageTestFitness;
 import org.evosuite.coverage.cbranch.CBranchFitnessFactory;
 import org.evosuite.coverage.cbranch.CBranchSuiteFitness;
+import org.evosuite.coverage.cbranch.CBranchTestFitness;
 import org.evosuite.coverage.dataflow.AllDefsCoverageFactory;
 import org.evosuite.coverage.dataflow.AllDefsCoverageSuiteFitness;
+import org.evosuite.coverage.dataflow.AllDefsCoverageTestFitness;
 import org.evosuite.coverage.dataflow.DefUseCoverageFactory;
 import org.evosuite.coverage.dataflow.DefUseCoverageSuiteFitness;
+import org.evosuite.coverage.dataflow.DefUseCoverageTestFitness;
 import org.evosuite.coverage.exception.ExceptionCoverageFactory;
 import org.evosuite.coverage.exception.ExceptionCoverageSuiteFitness;
+import org.evosuite.coverage.exception.ExceptionCoverageTestFitness;
 import org.evosuite.coverage.exception.TryCatchCoverageFactory;
 import org.evosuite.coverage.exception.TryCatchCoverageSuiteFitness;
+import org.evosuite.coverage.exception.TryCatchCoverageTestFitness;
 import org.evosuite.coverage.ibranch.IBranchFitnessFactory;
 import org.evosuite.coverage.ibranch.IBranchSuiteFitness;
+import org.evosuite.coverage.ibranch.IBranchTestFitness;
 import org.evosuite.coverage.io.input.InputCoverageFactory;
 import org.evosuite.coverage.io.input.InputCoverageSuiteFitness;
+import org.evosuite.coverage.io.input.InputCoverageTestFitness;
 import org.evosuite.coverage.io.output.OutputCoverageFactory;
 import org.evosuite.coverage.io.output.OutputCoverageSuiteFitness;
+import org.evosuite.coverage.io.output.OutputCoverageTestFitness;
 import org.evosuite.coverage.line.LineCoverageFactory;
 import org.evosuite.coverage.line.LineCoverageSuiteFitness;
+import org.evosuite.coverage.line.LineCoverageTestFitness;
 import org.evosuite.coverage.line.OnlyLineCoverageSuiteFitness;
-import org.evosuite.coverage.method.*;
-import org.evosuite.coverage.mutation.*;
+import org.evosuite.coverage.method.MethodCoverageFactory;
+import org.evosuite.coverage.method.MethodCoverageSuiteFitness;
+import org.evosuite.coverage.method.MethodCoverageTestFitness;
+import org.evosuite.coverage.method.MethodNoExceptionCoverageFactory;
+import org.evosuite.coverage.method.MethodNoExceptionCoverageSuiteFitness;
+import org.evosuite.coverage.method.MethodNoExceptionCoverageTestFitness;
+import org.evosuite.coverage.method.MethodTraceCoverageFactory;
+import org.evosuite.coverage.method.MethodTraceCoverageSuiteFitness;
+import org.evosuite.coverage.method.MethodTraceCoverageTestFitness;
+import org.evosuite.coverage.mutation.MutationFactory;
+import org.evosuite.coverage.mutation.MutationTestFitness;
+import org.evosuite.coverage.mutation.OnlyMutationFactory;
+import org.evosuite.coverage.mutation.OnlyMutationSuiteFitness;
+import org.evosuite.coverage.mutation.OnlyMutationTestFitness;
+import org.evosuite.coverage.mutation.StrongMutationSuiteFitness;
+import org.evosuite.coverage.mutation.StrongMutationTestFitness;
+import org.evosuite.coverage.mutation.WeakMutationSuiteFitness;
+import org.evosuite.coverage.mutation.WeakMutationTestFitness;
 import org.evosuite.coverage.readability.ReadabilitySuiteFitness;
 import org.evosuite.coverage.rho.RhoCoverageFactory;
 import org.evosuite.coverage.rho.RhoCoverageSuiteFitness;
 import org.evosuite.coverage.statement.StatementCoverageFactory;
 import org.evosuite.coverage.statement.StatementCoverageSuiteFitness;
+import org.evosuite.coverage.statement.StatementCoverageTestFitness;
 import org.evosuite.regression.RegressionSuiteFitness;
 import org.evosuite.testcase.TestFitnessFunction;
 import org.evosuite.testsuite.TestSuiteFitnessFunction;
@@ -195,4 +223,67 @@ public class FitnessFunctions {
 			return new BranchCoverageFactory();
 		}
 	}
+
+	/**
+	 * Converts a {@link org.evosuite.Properties.Criterion} object to a
+	 * {@link org.evosuite.testcase.TestFitnessFunction} class.
+	 * 
+	 * @param criterion a {@link org.evosuite.Properties.Criterion} object.
+	 * @return a {@link java.lang.Class} object.
+	 */
+	public static Class<?> getTestFitnessFunctionClass(Criterion criterion) {
+		switch (criterion) {
+		case STRONGMUTATION:
+				return StrongMutationTestFitness.class;
+		case WEAKMUTATION:
+				return WeakMutationTestFitness.class;
+		case MUTATION:
+				return MutationTestFitness.class;
+		case ONLYMUTATION:
+				return OnlyMutationTestFitness.class;
+		case DEFUSE:
+				return DefUseCoverageTestFitness.class;
+		case BRANCH:
+				return BranchCoverageTestFitness.class;
+		case CBRANCH:
+				return CBranchTestFitness.class;
+		case IBRANCH:
+				return IBranchTestFitness.class;
+		case STATEMENT:
+				return StatementCoverageTestFitness.class;
+		case RHO:
+				return LineCoverageTestFitness.class;
+		case AMBIGUITY:
+				return LineCoverageTestFitness.class;
+		case ALLDEFS:
+				return AllDefsCoverageTestFitness.class;
+		case EXCEPTION:
+				return ExceptionCoverageTestFitness.class;
+		case REGRESSION:
+				throw new RuntimeException("No test fitness function defined for " + criterion.name());
+		case READABILITY:
+				throw new RuntimeException("No test fitness function defined for " + criterion.name());
+		case ONLYBRANCH:
+				return OnlyBranchCoverageTestFitness.class;
+		case METHODTRACE:
+				return MethodTraceCoverageTestFitness.class;
+		case METHOD:
+				return MethodCoverageTestFitness.class;
+		case METHODNOEXCEPTION:
+				return MethodNoExceptionCoverageTestFitness.class;
+		case ONLYLINE:
+				return LineCoverageTestFitness.class;
+		case LINE:
+				return LineCoverageTestFitness.class;
+		case OUTPUT:
+				return OutputCoverageTestFitness.class;
+		case INPUT:
+				return InputCoverageTestFitness.class;
+		case TRYCATCH:
+				return TryCatchCoverageTestFitness.class;
+		default:
+				throw new RuntimeException("No criterion defined for " + criterion.name());
+		}
+	}
+
 }

--- a/client/src/main/java/org/evosuite/ga/archive/Archive.java
+++ b/client/src/main/java/org/evosuite/ga/archive/Archive.java
@@ -28,6 +28,7 @@ import java.util.Map;
 import java.util.Set;
 import org.evosuite.Properties;
 import org.evosuite.ga.Chromosome;
+import org.evosuite.ga.SecondaryObjective;
 import org.evosuite.runtime.util.AtMostOnceLogger;
 import org.evosuite.setup.TestCluster;
 import org.evosuite.testcase.TestCase;
@@ -87,8 +88,8 @@ public abstract class Archive<F extends TestFitnessFunction, T extends TestChrom
 
   /**
    * Register a collection of targets.
-   * 
-   * @param target
+   *
+   * @param targets
    */
   public void addTargets(Collection<F> targets) {
     for (F target : targets) {
@@ -190,12 +191,22 @@ public abstract class Archive<F extends TestFitnessFunction, T extends TestChrom
     // only look at other properties (e.g., length) if penalty scores are the same
     assert penaltyCandidateSolution == penaltyCurrentSolution;
 
+    // Check if the number of secondary objectives is the same for the two test cases
+    // otherwise something should be wrong
+    assert candidateSolution.getSecondaryObjectives().size() == currentSolution.getSecondaryObjectives().size();
+
     // If we try to add a test for a target we've already covered
     // and the new test is shorter, keep the shorter one
-    // TODO should not this be based on the SECONDARY_CRITERIA?
-    if (candidateSolution.size() < currentSolution.size()) {
-      return true;
+    int timesBetter = 0;
+    for (SecondaryObjective obj : candidateSolution.getSecondaryObjectives()) {
+      if (obj.compareChromosomes(candidateSolution, currentSolution) < 0)
+          timesBetter++;
+      else
+          timesBetter--;
     }
+
+    if (timesBetter > 0)
+      return true;
 
     return false;
   }
@@ -400,8 +411,8 @@ public abstract class Archive<F extends TestFitnessFunction, T extends TestChrom
    * Calculate the penalty of a {@link org.evosuite.testcase.TestCase}. A
    * {@link org.evosuite.testcase.TestCase} is penalised if it has functional mocks, or/and if it
    * accesses private fields/methods of the class under test.
-   * 
-   * @param a {@link org.evosuite.testcase.TestCase} object.
+   *
+   * @param testCase a {@link org.evosuite.testcase.TestCase} object.
    * @return number of penalty points
    */
   protected int calculatePenalty(TestCase testCase) {

--- a/client/src/main/java/org/evosuite/ga/archive/Archive.java
+++ b/client/src/main/java/org/evosuite/ga/archive/Archive.java
@@ -222,6 +222,15 @@ public abstract class Archive<F extends TestFitnessFunction, T extends TestChrom
   public abstract int getNumberOfCoveredTargets();
 
   /**
+   * Returns the total number of targets (of a specific type) covered by all solutions in the
+   * archive.
+   * 
+   * @param targetClass
+   * @return
+   */
+  public abstract int getNumberOfCoveredTargets(Class<?> targetClass);
+
+  /**
    * Returns the union of all targets covered by all solutions in the archive.
    * 
    * @return
@@ -234,6 +243,15 @@ public abstract class Archive<F extends TestFitnessFunction, T extends TestChrom
    * @return
    */
   public abstract int getNumberOfUncoveredTargets();
+
+  /**
+   * Returns the total number of targets (of a specific type) that have not been covered by any
+   * solution.
+   * 
+   * @param targetClass
+   * @return
+   */
+  public abstract int getNumberOfUncoveredTargets(Class<?> targetClass);
 
   /**
    * Returns a set of all targets that have not been covered by any solution.

--- a/client/src/main/java/org/evosuite/ga/archive/CoverageArchive.java
+++ b/client/src/main/java/org/evosuite/ga/archive/CoverageArchive.java
@@ -150,6 +150,15 @@ public class CoverageArchive<F extends TestFitnessFunction, T extends TestChromo
    * {@inheritDoc}
    */
   @Override
+  public int getNumberOfCoveredTargets(Class<?> targetClass) {
+    return (int) this.covered.keySet().stream().filter(target -> target.getClass() == targetClass)
+        .count();
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
   public Set<F> getCoveredTargets() {
     return this.covered.keySet();
   }
@@ -160,6 +169,14 @@ public class CoverageArchive<F extends TestFitnessFunction, T extends TestChromo
   @Override
   public int getNumberOfUncoveredTargets() {
     return this.uncovered.size();
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public int getNumberOfUncoveredTargets(Class<?> targetClass) {
+    return (int) this.uncovered.stream().filter(target -> target.getClass() == targetClass).count();
   }
 
   /**

--- a/client/src/main/java/org/evosuite/ga/archive/MIOArchive.java
+++ b/client/src/main/java/org/evosuite/ga/archive/MIOArchive.java
@@ -129,6 +129,15 @@ public class MIOArchive<F extends TestFitnessFunction, T extends TestChromosome>
    * {@inheritDoc}
    */
   @Override
+  public int getNumberOfCoveredTargets(Class<?> targetClass) {
+    return (int) this.getCoveredTargets().stream()
+        .filter(target -> target.getClass() == targetClass).count();
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
   public Set<F> getCoveredTargets() {
     return this.archive.keySet().stream().filter(target -> this.archive.get(target).isCovered())
         .collect(Collectors.toSet());
@@ -140,6 +149,15 @@ public class MIOArchive<F extends TestFitnessFunction, T extends TestChromosome>
   @Override
   public int getNumberOfUncoveredTargets() {
     return this.getUncoveredTargets().size();
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public int getNumberOfUncoveredTargets(Class<?> targetClass) {
+    return (int) this.getUncoveredTargets().stream()
+        .filter(target -> target.getClass() == targetClass).count();
   }
 
   /**

--- a/client/src/main/java/org/evosuite/ga/metaheuristics/GeneticAlgorithm.java
+++ b/client/src/main/java/org/evosuite/ga/metaheuristics/GeneticAlgorithm.java
@@ -763,7 +763,7 @@ public abstract class GeneticAlgorithm<T extends Chromosome> implements SearchAl
     /**
      * Write to a file all fitness values of each individuals.
      *
-     * @param solutions a list of {@link org.evosuite.ga.Chromosome} object(s).
+     * @param individuals a list of {@link org.evosuite.ga.Chromosome} object(s).
      */
     public void writeIndividuals(List<T> individuals) {
       if (!Properties.WRITE_INDIVIDUALS) {

--- a/client/src/main/java/org/evosuite/ga/metaheuristics/mosa/AbstractMOSA.java
+++ b/client/src/main/java/org/evosuite/ga/metaheuristics/mosa/AbstractMOSA.java
@@ -22,12 +22,14 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
+import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Set;
 import org.evosuite.ProgressMonitor;
 import org.evosuite.Properties;
-import org.evosuite.Properties.Criterion;
 import org.evosuite.Properties.SelectionFunction;
 import org.evosuite.coverage.FitnessFunctions;
 import org.evosuite.coverage.exception.ExceptionCoverageSuiteFitness;
@@ -70,8 +72,8 @@ public abstract class AbstractMOSA<T extends Chromosome> extends GeneticAlgorith
 
 	private static final Logger logger = LoggerFactory.getLogger(MOSA.class);
 
-	/** Keep track of overall suite fitness functions */
-	protected final List<TestSuiteFitnessFunction> suiteFitnessFunctions;
+	/** Keep track of overall suite fitness functions and correspondent test fitness functions */
+	protected final Map<TestSuiteFitnessFunction, Class<?>> suiteFitnessFunctions;
 
 	/** Object used to keep track of the execution time needed to reach the maximum coverage */
 	protected final BudgetConsumptionMonitor budgetMonitor;
@@ -84,10 +86,11 @@ public abstract class AbstractMOSA<T extends Chromosome> extends GeneticAlgorith
 	public AbstractMOSA(ChromosomeFactory<T> factory) {
 		super(factory);
 
-		this.suiteFitnessFunctions = new ArrayList<TestSuiteFitnessFunction>();
+		this.suiteFitnessFunctions = new LinkedHashMap<TestSuiteFitnessFunction, Class<?>>();
 		for (Properties.Criterion criterion : Properties.CRITERION) {
-			TestSuiteFitnessFunction fit = FitnessFunctions.getFitnessFunction(criterion);
-			this.suiteFitnessFunctions.add(fit);
+			TestSuiteFitnessFunction suiteFit = FitnessFunctions.getFitnessFunction(criterion);
+			Class<?> testFit = FitnessFunctions.getTestFitnessFunctionClass(criterion);
+			this.suiteFitnessFunctions.put(suiteFit, testFit);
 		}
 
 		this.budgetMonitor = new BudgetConsumptionMonitor();
@@ -483,7 +486,7 @@ public abstract class AbstractMOSA<T extends Chromosome> extends GeneticAlgorith
 
         // if one of the coverage criterion is Criterion.EXCEPTION, then we have to analyse the results
         // of the execution to look for generated exceptions
-        if (ArrayUtil.contains(Properties.CRITERION, Criterion.EXCEPTION)) {
+        if (ArrayUtil.contains(Properties.CRITERION, Properties.Criterion.EXCEPTION)) {
           TestChromosome testChromosome = (TestChromosome) c;
           ExceptionCoverageSuiteFitness.calculateExceptionInfo(
               Arrays.asList(testChromosome.getLastExecutionResult()),
@@ -510,14 +513,7 @@ public abstract class AbstractMOSA<T extends Chromosome> extends GeneticAlgorith
         }
 
         // compute overall fitness and coverage
-        double fitness = this.getNumberOfUncoveredGoals();
-        double coverage = ((double) this.getNumberOfCoveredGoals()) / ((double) this.getTotalNumberOfGoals());
-        for (TestSuiteFitnessFunction suiteFitness : this.suiteFitnessFunctions) {
-            bestTestCases.setFitness(suiteFitness, fitness);
-            bestTestCases.setCoverage(suiteFitness, coverage);
-            bestTestCases.setNumOfCoveredGoals(suiteFitness, this.getNumberOfCoveredGoals());
-            bestTestCases.setNumOfNotCoveredGoals(suiteFitness, this.getNumberOfUncoveredGoals());
-        }
+        this.computeCoverageAndFitness(bestTestCases);
 
         List<T> bests = new ArrayList<T>(1);
         bests.add((T) bestTestCases);
@@ -546,7 +542,7 @@ public abstract class AbstractMOSA<T extends Chromosome> extends GeneticAlgorith
           for (T test : this.getNonDominatedSolutions(this.population)) {
             best.addTest((TestChromosome) test);
           }
-          for (TestSuiteFitnessFunction suiteFitness : this.suiteFitnessFunctions) {
+          for (TestSuiteFitnessFunction suiteFitness : this.suiteFitnessFunctions.keySet()) {
             best.setCoverage(suiteFitness, 0.0);
             best.setFitness(suiteFitness,  1.0);
           }
@@ -554,13 +550,28 @@ public abstract class AbstractMOSA<T extends Chromosome> extends GeneticAlgorith
         }
 
         // compute overall fitness and coverage
-        double fitness = this.getNumberOfUncoveredGoals();
-        double coverage = ((double) this.getNumberOfCoveredGoals()) / ((double) this.getTotalNumberOfGoals());
-        for (TestSuiteFitnessFunction suiteFitness : this.suiteFitnessFunctions) {
-            best.setCoverage(suiteFitness, coverage);
-            best.setFitness(suiteFitness,  fitness);
-        }
+        this.computeCoverageAndFitness(best);
 
         return (T) best;
     }
+
+    private void computeCoverageAndFitness(TestSuiteChromosome suite) {
+      for (Entry<TestSuiteFitnessFunction, Class<?>> entry : this.suiteFitnessFunctions
+          .entrySet()) {
+        TestSuiteFitnessFunction suiteFitnessFunction = entry.getKey();
+        Class<?> testFitnessFunction = entry.getValue();
+
+        int numberCoveredTargets =
+            Archive.getArchiveInstance().getNumberOfCoveredTargets(testFitnessFunction);
+        int numberUncoveredTargets =
+            Archive.getArchiveInstance().getNumberOfUncoveredTargets(testFitnessFunction);
+
+        suite.setFitness(suiteFitnessFunction, ((double) numberUncoveredTargets));
+        suite.setCoverage(suiteFitnessFunction, ((double) numberCoveredTargets)
+            / ((double) (numberCoveredTargets + numberUncoveredTargets)));
+        suite.setNumOfCoveredGoals(suiteFitnessFunction, numberCoveredTargets);
+        suite.setNumOfNotCoveredGoals(suiteFitnessFunction, numberUncoveredTargets);
+      }
+    }
+
 }


### PR DESCRIPTION
Hi,

By default, EvoSuite's whole test suite generation computes the overall coverage as the average of the coverage scores of each single coverage criterion. On the other hand, the overall coverage returned by MOSA is computed as the total number of covered targets (whatever they are) divided by the total number of goals.

Example:

|  | EvoSuite |  | MOSA | |
| --- | :---: | :---: | :---: | :---: |
|  | #Covered Goals / #Goals | % | #Covered Goals / #Goals | % |
| Line | 56 / 56 | 100% | 56 / 56 | 100% |
| Branch | 31 / 31 | 100% | 31 / 31 | 100% |
| Exception | 8 / 8 | 100% | 9 / 9 | 100% |
| WeakMutation | 3 / 3 | 100% | 3 / 3 | 100% |
| Output | 2 / 5 | 40% | 2 / 5 | 40% |
| Method | 4 / 4 | 100% | 4 / 4 | 100% |
| Method-No-Exception | 4 / 4 | 100% | 4 / 4 | 100% |
| CBranch | 31 / 31 | 100% | 31 / 31 | 100% |

The overall coverage return by EvoSuite is:
```
100% + 100% + 100% + 100% + 40% + 100% + 100% + 100%
----------------------------------------------------- = 92.5%
                          8
```

MOSA overall coverage is:
```
#Covered Goals     56 + 31 + 9 + 3 + 2 + 4 + 4 + 31     140
                  ---------------------------------- = ----- = 97.9%
#Goals             56 + 31 + 9 + 3 + 5 + 4 + 4 + 31     143
```

Although the % coverage of each single coverage criterion is exactly the same on both approaches, MOSA reports **5.4%** more coverage than EvoSuite. In order to be consistent (and so that all criteria have the same weight when calculating the overall coverage) this PR adapts MOSA's computation of the overall coverage to the same used by EvoSuite.

@apanichella, any thoughts?
