### PR TITLE
Handing multiple secondary criteria in the Archive

### DIFF
--- a/client/src/main/java/org/evosuite/ga/archive/Archive.java
+++ b/client/src/main/java/org/evosuite/ga/archive/Archive.java
@@ -28,6 +28,7 @@ import java.util.Map;
 import java.util.Set;
 import org.evosuite.Properties;
 import org.evosuite.ga.Chromosome;
+import org.evosuite.ga.SecondaryObjective;
 import org.evosuite.runtime.util.AtMostOnceLogger;
 import org.evosuite.setup.TestCluster;
 import org.evosuite.testcase.TestCase;
@@ -87,8 +88,8 @@ public abstract class Archive<F extends TestFitnessFunction, T extends TestChrom
 
   /**
    * Register a collection of targets.
-   * 
-   * @param target
+   *
+   * @param targets
    */
   public void addTargets(Collection<F> targets) {
     for (F target : targets) {
@@ -190,12 +191,22 @@ public abstract class Archive<F extends TestFitnessFunction, T extends TestChrom
     // only look at other properties (e.g., length) if penalty scores are the same
     assert penaltyCandidateSolution == penaltyCurrentSolution;
 
+    // Check if the number of secondary objectives is the same for the two test cases
+    // otherwise something should be wrong
+    assert candidateSolution.getSecondaryObjectives().size() == currentSolution.getSecondaryObjectives().size();
+
     // If we try to add a test for a target we've already covered
     // and the new test is shorter, keep the shorter one
-    // TODO should not this be based on the SECONDARY_CRITERIA?
-    if (candidateSolution.size() < currentSolution.size()) {
-      return true;
+    int timesBetter = 0;
+    for (SecondaryObjective obj : candidateSolution.getSecondaryObjectives()) {
+      if (obj.compareChromosomes(candidateSolution, currentSolution) < 0)
+          timesBetter++;
+      else
+          timesBetter--;
     }
+
+    if (timesBetter > 0)
+      return true;
 
     return false;
   }
@@ -400,8 +411,8 @@ public abstract class Archive<F extends TestFitnessFunction, T extends TestChrom
    * Calculate the penalty of a {@link org.evosuite.testcase.TestCase}. A
    * {@link org.evosuite.testcase.TestCase} is penalised if it has functional mocks, or/and if it
    * accesses private fields/methods of the class under test.
-   * 
-   * @param a {@link org.evosuite.testcase.TestCase} object.
+   *
+   * @param testCase a {@link org.evosuite.testcase.TestCase} object.
    * @return number of penalty points
    */
   protected int calculatePenalty(TestCase testCase) {


### PR DESCRIPTION
The previous version of the code was using the test length as default (fixed( secondary criterion instead of the secondary objective set in the class Properties.Java

This commit updates the archive and allows to handle multiple secondary objectives: the test case that wins the comparison is the one that is better for the majority of secondary objectives (majority vote schema).