### PR TITLE
Make logback dependency optional

### DIFF
--- a/client/pom.xml
+++ b/client/pom.xml
@@ -75,6 +75,7 @@
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
+            <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>com.googlecode.gentyref</groupId>

--- a/master/pom.xml
+++ b/master/pom.xml
@@ -76,6 +76,11 @@
             <artifactId>cdi-api</artifactId>
             <scope>compile</scope>
         </dependency>
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+            <optional>true</optional>
+        </dependency>
 
     </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -258,6 +258,7 @@
                     JobExecutorIntTest and all the Maven ones) work fine
                     on Windows -->
                 <version>1.1.3</version>
+                <optional>true</optional>
             </dependency>
             <dependency>
                 <!-- MIT -->

--- a/runtime/pom.xml
+++ b/runtime/pom.xml
@@ -42,6 +42,7 @@
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
             <scope>test</scope>
+            <optional>true</optional>
             <!-- shouldn't end up in final jar-->
         </dependency>
 


### PR DESCRIPTION
Currently, anyone who has Evosuite as a dependency will have `ch.qos.logback` as a transitive dependency. Anyone who wishes to bind a different logger (e.g. `slf4j-nop`) will encounter the warning "Class path contains multiple SLF4J bindings." According to the [SLF4J FAQ](https://www.slf4j.org/codes.html#multiple_bindings), the solution is to *not* make the binding itself a dependency, but only the API.

---

This PR does two things:
1. It makes `ch.qos.logback` an [optional dependency](https://maven.apache.org/guides/introduction/introduction-to-optional-and-excludes-dependencies.html), which means that it is a required dependency when compiling Evosuite, but will not be a dependency of projects that use Evosuite. This will allow users of Evosuite to use their own logger binder.
2. It adds `ch.qos.logback` as an optional dependency to the `master` module, because it implicitly assumed that its dependencies would expose it transitively, but its dependencies no longer do that because of change 1. describe above. 