### PR TITLE
fix for ignoring value of -Dtools_jar_location

### DIFF
--- a/master/src/main/java/org/evosuite/EvoSuite.java
+++ b/master/src/main/java/org/evosuite/EvoSuite.java
@@ -152,10 +152,6 @@ public class EvoSuite {
 
             setupProperties();
 
-            if (TestSuiteWriterUtils.needToUseAgent() && Properties.JUNIT_CHECK) {
-                ClassPathHacker.initializeToolJar();
-            }
-
             if (!line.hasOption("regressionSuite")) {
                 if (line.hasOption("criterion")) {
                     //TODO should check if already defined
@@ -181,6 +177,10 @@ public class EvoSuite {
 
             CommandLineParameters.addJavaDOptions(javaOpts, line);
 
+            if (TestSuiteWriterUtils.needToUseAgent() && Properties.JUNIT_CHECK) {
+                ClassPathHacker.initializeToolJar();
+            }
+            
             CommandLineParameters.handleClassPath(line);
 
             CommandLineParameters.handleJVMOptions(javaOpts, line);


### PR DESCRIPTION
FIX: EvoSuite ignores -Dtools_jar_location="path" when it is given via the command line. This is because the given javaD options are evaluated later than the initialization of the tools.jar.