### PR TITLE
MockWindowsFileSystemView returns the home directory of the drive containing the executing code

### DIFF
--- a/runtime/src/main/java/org/evosuite/runtime/mock/javax/swing/filechooser/MockFileSystemView.java
+++ b/runtime/src/main/java/org/evosuite/runtime/mock/javax/swing/filechooser/MockFileSystemView.java
@@ -529,10 +529,19 @@ class MockWindowsFileSystemView extends MockFileSystemView {
 	}
 
 	/**
-	 * @return the Desktop folder.
+	 * @return the home directory on the drive the code exists on.
 	 */
 	public File getHomeDirectory() {
-		return getRoots()[0];
+		File executionPath = createFileObject(System.getProperty("user.dir"));
+		File[] roots = getRoots();
+
+		for (File root : roots) {
+			if(root.toPath().getRoot().equals(executionPath.toPath().getRoot())) {
+				return root;
+			}
+		}
+
+		return roots[0];
 	}
 
 	/**


### PR DESCRIPTION
Resolves #220, in which it was discovered that, on Windows, storing the source code a drive other than `C:\` causes test failures (and probably unexpected behaviours). This PR changes the implementation of `MockWindowsFileSystemView::getHomeDirectory()` to return the home directory of the drive on which the code is stored.