### PR TITLE
Fix a bug in the docker images

### DIFF
--- a/Dockerfile.java11
+++ b/Dockerfile.java11
@@ -1,5 +1,5 @@
 # Container image for building the project
-FROM maven:3-openjdk-11-slim as build
+FROM maven:3-openjdk-11 as build
 LABEL maintainer="Mitchell Olsthoorn"
 
 # Parameter for skipping the tests in the build process
@@ -24,8 +24,8 @@ RUN mvn -e -B package -DskipTests=${SKIP_TESTS} && \
     mv master/target/evosuite-master-*-tests.jar bin/evosuite-tests.jar && \
     mv master/target/evosuite-master-*.jar bin/evosuite.jar
 
-# Slim container image for running EvoSuite
-FROM openjdk:11-jdk-slim
+# Container image for running EvoSuite
+FROM openjdk:11-jdk
 
 WORKDIR /evosuite
 VOLUME /evosuite

--- a/Dockerfile.java11-experiment
+++ b/Dockerfile.java11-experiment
@@ -1,5 +1,5 @@
 # Container image for building the project
-FROM maven:3-openjdk-11-slim as build
+FROM maven:3-openjdk-11 as build
 LABEL maintainer="Mitchell Olsthoorn"
 
 # Parameter for skipping the tests in the build process
@@ -24,8 +24,8 @@ RUN mvn -e -B package -DskipTests=${SKIP_TESTS} && \
     mv master/target/evosuite-master-*-tests.jar bin/evosuite-tests.jar && \
     mv master/target/evosuite-master-*.jar bin/evosuite.jar
 
-# Slim container image for running EvoSuite
-FROM openjdk:11-jdk-slim
+# Container image for running EvoSuite
+FROM openjdk:11-jdk
 
 WORKDIR /evosuite
 VOLUME /evosuite

--- a/Dockerfile.java8
+++ b/Dockerfile.java8
@@ -1,5 +1,5 @@
 # Container image for building the project
-FROM maven:3-openjdk-8-slim as build
+FROM maven:3-openjdk-8 as build
 LABEL maintainer="Mitchell Olsthoorn"
 
 # Parameter for skipping the tests in the build process
@@ -24,8 +24,8 @@ RUN mvn -e -B package -DskipTests=${SKIP_TESTS} && \
     mv master/target/evosuite-master-*-tests.jar bin/evosuite-tests.jar && \
     mv master/target/evosuite-master-*.jar bin/evosuite.jar
 
-# Slim container image for running EvoSuite
-FROM openjdk:8-jdk-slim
+# Container image for running EvoSuite
+FROM openjdk:8-jdk
 
 WORKDIR /evosuite
 VOLUME /evosuite

--- a/Dockerfile.java8-experiment
+++ b/Dockerfile.java8-experiment
@@ -1,5 +1,5 @@
 # Container image for building the project
-FROM maven:3-openjdk-8-slim as build
+FROM maven:3-openjdk-8 as build
 LABEL maintainer="Mitchell Olsthoorn"
 
 # Parameter for skipping the tests in the build process
@@ -24,8 +24,8 @@ RUN mvn -e -B package -DskipTests=${SKIP_TESTS} && \
     mv master/target/evosuite-master-*-tests.jar bin/evosuite-tests.jar && \
     mv master/target/evosuite-master-*.jar bin/evosuite.jar
 
-# Slim container image for running EvoSuite
-FROM openjdk:8-jdk-slim
+# Container image for running EvoSuite
+FROM openjdk:8-jdk
 
 WORKDIR /evosuite
 VOLUME /evosuite


### PR DESCRIPTION
The docker images were not properly working anymore after the base
images removed some dependencies. This commit changes the base image to
the non-slim variant which still includes the required dependency.

Fixes #360 