### PR TITLE
Avoid comparing equal chromosomes

### DIFF
--- a/client/src/main/java/org/evosuite/ga/archive/Archive.java
+++ b/client/src/main/java/org/evosuite/ga/archive/Archive.java
@@ -155,6 +155,10 @@ public abstract class Archive implements Serializable {
      */
     public boolean isBetterThanCurrent(TestChromosome currentSolution, TestChromosome candidateSolution) {
 
+        if (currentSolution.equals(candidateSolution)) {
+            return false;
+        }
+ 
         ExecutionResult currentSolutionExecution = currentSolution.getLastExecutionResult();
         ExecutionResult candidateSolutionExecution = candidateSolution.getLastExecutionResult();
         if (currentSolutionExecution != null


### PR DESCRIPTION
The "isBetterThanCurrent" method of the "Archive" class checks if a candidate solution is better than an existing one even when both solutions are equal (this method will always return false in such circumstances).

Wouldn't it be better to verify whether the solutions are equal before checking which solution is the best?