### PR TITLE
fix Sandbox clear

### DIFF
--- a/client/src/main/java/org/evosuite/junit/writer/Scaffolding.java
+++ b/client/src/main/java/org/evosuite/junit/writer/Scaffolding.java
@@ -576,7 +576,7 @@ public class Scaffolding {
 
     private void generateAfterClass(StringBuilder bd, boolean wasSecurityException, List<ExecutionResult> results) {
 
-        if (wasSecurityException || TestSuiteWriterUtils.shouldResetProperties(results)) {
+        if (Properties.RESET_STATIC_FIELDS || wasSecurityException || TestSuiteWriterUtils.shouldResetProperties(results)) {
             bd.append(METHOD_SPACE);
             bd.append("@").append(getAdapter().afterAll().getSimpleName()).append("\n");
             bd.append(METHOD_SPACE);


### PR DESCRIPTION
When Properties.RESET_STATIC_FIELDS is true and wasSecurityException || TestSuiteWriterUtils.shouldResetProperties(results) is false,this tool will generate code "Sandbox.initializeSecurityManagerForSUT();" but without code "Sandbox.resetDefaultSecurityManager();".It made securitymanager did not reset,which would make crash on tests on jacoco.