### PR TITLE
Support target_method functioning for MutationFactory

### DIFF
--- a/client/src/main/java/org/evosuite/coverage/mutation/MutationFactory.java
+++ b/client/src/main/java/org/evosuite/coverage/mutation/MutationFactory.java
@@ -22,6 +22,7 @@ package org.evosuite.coverage.mutation;
 
 import org.evosuite.Properties;
 import org.evosuite.TestGenerationContext;
+import org.evosuite.coverage.MethodNameMatcher;
 import org.evosuite.instrumentation.mutation.InsertUnaryOperator;
 import org.evosuite.instrumentation.mutation.ReplaceArithmeticOperator;
 import org.evosuite.instrumentation.mutation.ReplaceConstant;
@@ -29,6 +30,8 @@ import org.evosuite.instrumentation.mutation.ReplaceVariable;
 import org.evosuite.rmi.ClientServices;
 import org.evosuite.statistics.RuntimeVariable;
 import org.evosuite.testsuite.AbstractFitnessFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -45,6 +48,12 @@ public class MutationFactory extends AbstractFitnessFactory<MutationTestFitness>
     private boolean strong = true;
 
     protected List<MutationTestFitness> goals = null;
+
+    private static final Logger logger = LoggerFactory.getLogger(MutationFactory.class);
+
+
+    private final MethodNameMatcher matcher = new MethodNameMatcher();
+
 
     /**
      * <p>
@@ -94,6 +103,12 @@ public class MutationFactory extends AbstractFitnessFactory<MutationTestFitness>
         for (Mutation m : getMutantsLimitedPerClass()) {
             if (targetMethod != null && !m.getMethodName().endsWith(targetMethod))
                 continue;
+
+            String methodName = m.getMethodName();
+            if(!matcher.methodMatches(methodName)) {
+                logger.info("Method {} does not match criteria. ", methodName);
+                continue;
+            }
 
             // We need to return all mutants to make coverage values and bitstrings consistent
             //if (MutationTimeoutStoppingCondition.isDisabled(m))

--- a/master/src/test/java/org/evosuite/basic/TargetMethodListSystemTest.java
+++ b/master/src/test/java/org/evosuite/basic/TargetMethodListSystemTest.java
@@ -1,0 +1,31 @@
+package org.evosuite.basic;
+
+import com.examples.with.different.packagename.TargetMethod;
+import org.evosuite.EvoSuite;
+import org.evosuite.Properties;
+import org.evosuite.SystemTestBase;
+import org.evosuite.ga.metaheuristics.GeneticAlgorithm;
+import org.evosuite.testsuite.TestSuiteChromosome;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class TargetMethodListSystemTest extends SystemTestBase {
+    @Test
+    public void testTargetMethodWithBranchCoverage() {
+        EvoSuite evosuite = new EvoSuite();
+
+        String targetClass = TargetMethod.class.getCanonicalName();
+        String targetMethod = "foo(Ljava/lang/Integer;)Z";
+        Properties.TARGET_CLASS = targetClass;
+        Properties.TARGET_METHOD_LIST = targetMethod;
+        Properties.CRITERION = new Properties.Criterion[]{Properties.Criterion.BRANCH, Properties.Criterion.WEAKMUTATION};
+        String[] command = new String[]{"-generateMOSuite", "-class", targetClass};
+
+        Object result = evosuite.parseCommandLine(command);
+
+        GeneticAlgorithm<TestSuiteChromosome> ga = getGAFromResult(result);
+        TestSuiteChromosome best = ga.getBestIndividual();
+        Assert.assertTrue(best.toString().contains("foo"));
+        Assert.assertFalse(best.toString().contains("bar"));
+    }
+}


### PR DESCRIPTION
As shown in [the issue](https://github.com/EvoSuite/evosuite/issues/429), A crash happens when we use the `target_method` functioning with DynaMOSA. This is because:
 To implement `target_method_list`, the developers select the target methods' fitness function in Factory class family, such as [branch coverage](https://github.com/EvoSuite/evosuite/blob/master/client/src/main/java/org/evosuite/coverage/branch/BranchCoverageFactory.java#L75). 
1. But the developers do not implement this functioning for the Mutation criterion. 
2. As a result, all mutation fitness functions are added to the genetic algorithms.
3. When the GA is DynaMOSA, it dynamically selects goals by analyzing the dependence relationships among all goals. When DynaMOSA tries to analyze the relationship between branch fitness functions and a mutation fitness function that are not in the target method, the crash happens since branch fitness functions are not added to genetic algorithms.

To fix it, I made a slight change in MutationFactory, following the way of other criterion factories.
