### PR TITLE
Heuristics for variable naming

### DIFF
--- a/client/src/main/java/org/evosuite/Properties.java
+++ b/client/src/main/java/org/evosuite/Properties.java
@@ -1248,7 +1248,7 @@ public class Properties {
     }
 
     @Parameter(key = "variable_naming_strategy", group = "Output", description = "What strategy to use to derive names for variables")
-    public static VariableNamingStrategy VARIABLE_NAMING_STRATEGY = VariableNamingStrategy.HEURISTICS_BASED;
+    public static VariableNamingStrategy VARIABLE_NAMING_STRATEGY = VariableNamingStrategy.TYPE_BASED;
 
     // ---------------------------------------------------------------
     // Sandbox

--- a/client/src/main/java/org/evosuite/Properties.java
+++ b/client/src/main/java/org/evosuite/Properties.java
@@ -1248,7 +1248,7 @@ public class Properties {
     }
 
     @Parameter(key = "variable_naming_strategy", group = "Output", description = "What strategy to use to name variables for tests")
-    public static VariableNamingStrategy VARIABLE_NAMING_STRATEGY = VariableNamingStrategy.HEURISTICS_BASED;
+    public static VariableNamingStrategy VARIABLE_NAMING_STRATEGY = VariableNamingStrategy.TYPE_BASED;
 
     // ---------------------------------------------------------------
     // Sandbox

--- a/client/src/main/java/org/evosuite/Properties.java
+++ b/client/src/main/java/org/evosuite/Properties.java
@@ -1244,7 +1244,7 @@ public class Properties {
     public static TestNamingStrategy TEST_NAMING_STRATEGY = TestNamingStrategy.NUMBERED;
 
     public enum VariableNamingStrategy {
-        TYPE_BASED, HEURISTICS_BASED, INFO_COLLECTOR
+        TYPE_BASED, HEURISTICS_BASED
     }
 
     @Parameter(key = "variable_naming_strategy", group = "Output", description = "What strategy to use to name variables for tests")

--- a/client/src/main/java/org/evosuite/Properties.java
+++ b/client/src/main/java/org/evosuite/Properties.java
@@ -1234,12 +1234,21 @@ public class Properties {
     @Parameter(key = "max_coverage_depth", group = "Output", description = "Maximum depth in the calltree to count a branch as covered")
     public static int MAX_COVERAGE_DEPTH = -1;
 
+    // ---------------------------------------------------------------
+    // Naming
     public enum TestNamingStrategy {
         NUMBERED, COVERAGE
     }
 
     @Parameter(key = "test_naming_strategy", group = "Output", description = "What strategy to use to derive names for tests")
     public static TestNamingStrategy TEST_NAMING_STRATEGY = TestNamingStrategy.NUMBERED;
+
+    public enum VariableNamingStrategy {
+        TYPE_BASED, HEURISTICS_BASED, INFO_COLLECTOR
+    }
+
+    @Parameter(key = "variable_naming_strategy", group = "Output", description = "What strategy to use to name variables for tests")
+    public static VariableNamingStrategy VARIABLE_NAMING_STRATEGY = VariableNamingStrategy.HEURISTICS_BASED;
 
     // ---------------------------------------------------------------
     // Sandbox

--- a/client/src/main/java/org/evosuite/Properties.java
+++ b/client/src/main/java/org/evosuite/Properties.java
@@ -1244,11 +1244,11 @@ public class Properties {
     public static TestNamingStrategy TEST_NAMING_STRATEGY = TestNamingStrategy.NUMBERED;
 
     public enum VariableNamingStrategy {
-        TYPE_BASED
+        TYPE_BASED, HEURISTICS_BASED
     }
 
     @Parameter(key = "variable_naming_strategy", group = "Output", description = "What strategy to use to derive names for variables")
-    public static VariableNamingStrategy VARIABLE_NAMING_STRATEGY = VariableNamingStrategy.TYPE_BASED;
+    public static VariableNamingStrategy VARIABLE_NAMING_STRATEGY = VariableNamingStrategy.HEURISTICS_BASED;
 
     // ---------------------------------------------------------------
     // Sandbox

--- a/client/src/main/java/org/evosuite/testcase/TestCodeVisitor.java
+++ b/client/src/main/java/org/evosuite/testcase/TestCodeVisitor.java
@@ -77,8 +77,13 @@ public class TestCodeVisitor extends TestVisitor {
     /**
      * Dictionaries for naming information
      */
+    /**
+     * Dictionaries for naming information
+     */
     protected Map<VariableReference, String> methodNames = new HashMap<>();
     protected Map<VariableReference, String> argumentNames = new HashMap<>();
+
+    private Map<String, Map<VariableReference, String>> information = new HashMap<>();
 
     /**
      * <p>
@@ -387,112 +392,15 @@ public class TestCodeVisitor extends TestVisitor {
             }
             return result;
         } else {
+            if(VariableNameStrategyFactory.gatherInformation()){
+                information.put("MethodNames", methodNames);
+                information.put("ArgumentNames", argumentNames);
+                variableNameStrategy.addVariableInformation(information);
+            }
             return variableNameStrategy.getNameForVariable(var);
         }
     }
 
-    /**
-     * Returns the suggested name for a variable according to Properties configuration
-     *
-     * 1. TYPE_BASED --> Using type names + index as suggested name (this is the traditional naming in EvoSuite)
-     * 2. HEURISTICS_BASED --> Using information about arguments + methods + types for proposing a name + index if name is repeated more than once
-     * 3. INFO_COLLECTOR --> Mode for controlling all the information about the test retrieved via reflection, only for debugging purposes
-     *
-     * @return String
-     */
-    private String getNameByStrategy(final VariableReference var, final String originalVariableName) {
-        String variableName = "";
-        if (Properties.VARIABLE_NAMING_STRATEGY == Properties.VariableNamingStrategy.TYPE_BASED) {
-            variableName = originalVariableName;
-            variableName = getIndexIncludingFirstAppearance(variableName);
-        }
-        if (Properties.VARIABLE_NAMING_STRATEGY == Properties.VariableNamingStrategy.HEURISTICS_BASED) {
-            variableName = this.getPrioritizedName(var, originalVariableName);
-            variableName = getVariableWithIndexExcludingFirstAppearance(variableName);
-        }
-        return variableName;
-    }
-
-    /**
-     * Returns the variable name + the corresponding index if and only if there is more than one repetition of the name,
-     * otherwise, it returns the name without an index at last.
-     *
-     * Mainly used for Heuristic Renaming Strategy.
-     *
-     * @return String
-     */
-    private String getVariableWithIndexExcludingFirstAppearance(String variableName) {
-        if (!this.nextIndices.containsKey(variableName)) {
-            this.nextIndices.put(variableName, 0);
-        }
-        else {
-            final int index = this.nextIndices.get(variableName);
-            this.nextIndices.put(variableName, index + 1);
-            variableName += this.nextIndices.get(variableName);
-        }
-        return variableName;
-    }
-
-    /**
-     * Returns the variable name + the number of repetitions counting from 0.
-     * i.e. If the variable appears only once in the test, it is named as variable0.
-     *
-     * Mainly used for Type-Based Renaming Strategy (traditional naming in EvoSuite).
-     *
-     * @return String
-     */
-    private String getIndexIncludingFirstAppearance(String variableName) {
-        if (!nextIndices.containsKey(variableName)) {
-            nextIndices.put(variableName, 0);
-        }
-        int index = nextIndices.get(variableName);
-        nextIndices.put(variableName, index + 1);
-        return variableName += index;
-    }
-    /**
-     * Retrieve a suggested name based on method, argument and type information.
-     *
-     * The followed order for prioritizing is:
-     * 1. Use argument suggestion, if not possible
-     * 2. Use method suggestion + reductions, if not possible
-     * 3. Use type suggestion, traditional naming.
-     *
-     * @return String
-     */
-    private String getPrioritizedName(final VariableReference var, String variableName) {
-        final String methodCode = this.methodNames.get(var);
-        final String arguments = this.argumentNames.get(var);
-        if (arguments != null) {
-            variableName = arguments;
-        }
-        else if (methodCode != null) {
-            variableName = analyzeMethodName(methodCode);
-        }
-        if(variableName.equals(var.getSimpleClassName())){
-            variableName = "_" + variableName;
-        }
-        return variableName;
-    }
-
-    /**
-     * Returns the suggested method name controlling camel case and excluding some particles
-     * of the method names.
-     *
-     * @return String
-     */
-    private String analyzeMethodName(String methodCode) {
-        String name = "";
-        ArrayList<String> methodName = HeuristicsUtil.separateByCamelCase(methodCode);
-        if(methodCode.length() > 0){
-            if(HeuristicsUtil.containsAvoidableParticle(methodName.get(0)) && methodName.size() > 1){
-                name = StringUtils.join(methodName.subList(1,methodName.size()), "");
-                final char[] auxCharArray = name.toCharArray();
-                auxCharArray[0] = Character.toLowerCase(auxCharArray[0]);
-                return new String(auxCharArray);
-            }
-        }
-        return methodCode;
-    }
 
     /**
      * Retrieve the names of all known variables
@@ -1445,7 +1353,7 @@ public class TestCodeVisitor extends TestVisitor {
 
         if (!retval.isVoid() && retval.getAdditionalVariableReference() == null
                 && !unused) {
-            if (!this.methodNames.containsKey(retval)) {
+            if (!this.methodNames.containsKey(retval) && VariableNameStrategyFactory.gatherInformation()) {
                 this.methodNames.put(retval, method.getName());
             }
             if (exception != null) {
@@ -1460,7 +1368,7 @@ public class TestCodeVisitor extends TestVisitor {
             result += "try { " + NEWLINE + "  ";
         }
 
-        if (!this.argumentNames.containsKey(retval)) {
+        if (!this.argumentNames.containsKey(retval) && VariableNameStrategyFactory.gatherInformation()) {
             final List<String> parameterNames = (List<String>)statement.obtainParameterNameListInOrder();
             int idx = 0;
             for (final VariableReference param : parameters) {
@@ -1468,7 +1376,7 @@ public class TestCodeVisitor extends TestVisitor {
                 ++idx;
             }
         }
-        if (retval.isVoid()) {
+        if (retval.isVoid() && VariableNameStrategyFactory.gatherInformation()) {
             final List<String> parameterNames = (List<String>)statement.obtainParameterNameListInOrder();
             int idx = 0;
             for (final VariableReference param : parameters) {
@@ -1704,8 +1612,8 @@ public class TestCodeVisitor extends TestVisitor {
                 && !Modifier.isStatic(constructor.getConstructor().getDeclaringClass().getModifiers());
 
         List<VariableReference> parameters = statement.getParameterReferences();
-        if (!this.argumentNames.containsKey(retval)) {
-            final List<String> parameterNames = (List<String>)statement.obtainParameterNameListInOrder();
+        if (!this.argumentNames.containsKey(retval) && VariableNameStrategyFactory.gatherInformation()) {
+            final List<String> parameterNames = statement.obtainParameterNameListInOrder();
             int idx = 0;
             for (final VariableReference param : parameters) {
                 this.argumentNames.put(param, parameterNames.get(idx));

--- a/client/src/main/java/org/evosuite/testcase/statements/ConstructorStatement.java
+++ b/client/src/main/java/org/evosuite/testcase/statements/ConstructorStatement.java
@@ -38,6 +38,7 @@ import org.objectweb.asm.Type;
 import java.io.PrintStream;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Modifier;
+import java.lang.reflect.Parameter;
 import java.util.*;
 
 /**
@@ -477,5 +478,35 @@ public class ConstructorStatement extends EntityWithParametersStatement {
     @Override
     public String getMethodName() {
         return "<init>";
+    }
+
+    /**
+     * Returns a list of the parameter names of a method using reflection. The list is in order of
+     * declaration in the method.
+     *
+     * @return List<String>
+     */
+    public List<String> obtainParameterNameListInOrder() {
+        final Parameter[] parameters = this.constructor.getParameters();
+        final List<String> names = new ArrayList<String>();
+        for (final Parameter p : parameters) {
+            names.add(p.getName());
+        }
+        return names;
+    }
+
+    /**
+     * Returns a string concatenation of the parameter names of a method using reflection.
+     * The string contains the parameter names separated by low bars, and in order of declaration
+     *
+     * @return String
+     */
+    public String obtainParameterNamesInOrder() {
+        final Parameter[] parameters = this.constructor.getParameters();
+        String names = "";
+        for (final Parameter p : parameters) {
+            names = names + p.getName() + "_";
+        }
+        return names;
     }
 }

--- a/client/src/main/java/org/evosuite/testcase/statements/ConstructorStatement.java
+++ b/client/src/main/java/org/evosuite/testcase/statements/ConstructorStatement.java
@@ -494,19 +494,4 @@ public class ConstructorStatement extends EntityWithParametersStatement {
         }
         return names;
     }
-
-    /**
-     * Returns a string concatenation of the parameter names of a method using reflection.
-     * The string contains the parameter names separated by low bars, and in order of declaration
-     *
-     * @return String
-     */
-    public String obtainParameterNamesInOrder() {
-        final Parameter[] parameters = this.constructor.getParameters();
-        String names = "";
-        for (final Parameter p : parameters) {
-            names = names + p.getName() + "_";
-        }
-        return names;
-    }
 }

--- a/client/src/main/java/org/evosuite/testcase/statements/MethodStatement.java
+++ b/client/src/main/java/org/evosuite/testcase/statements/MethodStatement.java
@@ -36,6 +36,7 @@ import org.objectweb.asm.Type;
 
 import java.io.PrintStream;
 import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Parameter;
 import java.util.*;
 import java.util.stream.Collectors;
 
@@ -649,5 +650,23 @@ public class MethodStatement extends EntityWithParametersStatement {
     @Override
     public String getMethodName() {
         return method.getName();
+    }
+
+    public List<String> obtainParameterNameListInOrder() {
+        final Parameter[] parameters = this.method.getParameters();
+        final List<String> names = new ArrayList<String>();
+        for (final Parameter p : parameters) {
+            names.add(p.getName());
+        }
+        return names;
+    }
+
+    public String obtainParameterNamesInOrder() {
+        final Parameter[] parameters = this.method.getParameters();
+        String names = "";
+        for (final Parameter p : parameters) {
+            names = names + p.getName() + "_";
+        }
+        return names;
     }
 }

--- a/client/src/main/java/org/evosuite/testcase/statements/MethodStatement.java
+++ b/client/src/main/java/org/evosuite/testcase/statements/MethodStatement.java
@@ -660,13 +660,4 @@ public class MethodStatement extends EntityWithParametersStatement {
         }
         return names;
     }
-
-    public String obtainParameterNamesInOrder() {
-        final Parameter[] parameters = this.method.getParameters();
-        String names = "";
-        for (final Parameter p : parameters) {
-            names = names + p.getName() + "_";
-        }
-        return names;
-    }
 }

--- a/client/src/main/java/org/evosuite/testcase/utils/HeuristicsUtil.java
+++ b/client/src/main/java/org/evosuite/testcase/utils/HeuristicsUtil.java
@@ -1,0 +1,39 @@
+package org.evosuite.testcase.utils;
+import java.util.ArrayList;
+
+public class HeuristicsUtil {
+    /**
+     * List of particles of a method name that can be excluded or avoided when syggesting names
+     */
+    private static ArrayList<String> avoidableParticles = new ArrayList<String>(){
+        {
+            add("get");
+            add("to");
+            add("has");
+            add("is");
+            add("are");
+        }
+    };
+
+    /**
+     * Returns a boolean value that indicates if the first word of a method can be avoided/excluded
+     * on method name suggestion
+     * @return boolean
+     */
+
+    public static boolean containsAvoidableParticle(String firstWord){
+        return avoidableParticles.contains(firstWord);
+    }
+    /**
+     * Separates camelcase strings and retrieves the parts in a list
+     * @return ArrayList<String>
+     */
+    public static ArrayList<String> separateByCamelCase(String name){
+        ArrayList<String> separatedName = new ArrayList<>();
+        for (String word : name.split("(?<!(^|[A-Z]))(?=[A-Z])|(?<!^)(?=[A-Z][a-z])")) {
+            separatedName.add(word);
+        }
+        return separatedName;
+    }
+
+}

--- a/client/src/main/java/org/evosuite/testcase/variable/name/HeuristicsVariableNameStrategy.java
+++ b/client/src/main/java/org/evosuite/testcase/variable/name/HeuristicsVariableNameStrategy.java
@@ -1,0 +1,97 @@
+package org.evosuite.testcase.variable.name;
+
+import org.apache.commons.lang3.StringUtils;
+import org.evosuite.testcase.utils.HeuristicsUtil;
+import org.evosuite.testcase.variable.VariableReference;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+public class HeuristicsVariableNameStrategy extends AbstractVariableNameStrategy{
+
+    protected final Map<String, Integer> nextIndices = new ConcurrentHashMap<>();
+    /**
+     * Dictionaries for naming information
+     */
+    protected Map<VariableReference, String> methodNames = new HashMap<>();
+    protected Map<VariableReference, String> argumentNames = new HashMap<>();
+
+    private TypeBasedVariableNameStrategy typeBasedVariableNameStrategy = new TypeBasedVariableNameStrategy();
+    @Override
+    public String createNameForVariable(VariableReference variable) {
+        String typeBasedName = typeBasedVariableNameStrategy.getPlainNameForVariable(variable);
+        return getPrioritizedName(variable, typeBasedName);
+    }
+
+    /**
+     * Returns the variable name + the corresponding index if and only if there is more than one repetition of the name,
+     * otherwise, it returns the name without an index at last.
+     *
+     * Mainly used for Heuristic Renaming Strategy.
+     *
+     * @return String
+     */
+    private String getVariableWithIndexExcludingFirstAppearance(String variableName) {
+        if (!this.nextIndices.containsKey(variableName)) {
+            this.nextIndices.put(variableName, 0);
+        }
+        else {
+            final int index = this.nextIndices.get(variableName);
+            this.nextIndices.put(variableName, index + 1);
+            variableName += this.nextIndices.get(variableName);
+        }
+        return variableName;
+    }
+    /**
+     * Retrieve a suggested name based on method, argument and type information.
+     *
+     * The followed order for prioritizing is:
+     * 1. Use argument suggestion, if not possible
+     * 2. Use method suggestion + reductions, if not possible
+     * 3. Use type suggestion, traditional naming.
+     *
+     * @return String
+     */
+    private String getPrioritizedName(final VariableReference var, String variableName) {
+        final String methodCode = this.methodNames.get(var);
+        final String arguments = this.argumentNames.get(var);
+        if (arguments != null) {
+            variableName = arguments;
+        }
+        else if (methodCode != null) {
+            variableName = analyzeMethodName(methodCode);
+        }
+        if(variableName.equals(var.getSimpleClassName())){
+            variableName = "_" + variableName;
+        }
+        return variableName;
+    }
+
+    /**
+     * Returns the suggested method name controlling camel case and excluding some particles
+     * of the method names.
+     *
+     * @return String
+     */
+    private String analyzeMethodName(String methodCode) {
+        String name = "";
+        ArrayList<String> methodName = HeuristicsUtil.separateByCamelCase(methodCode);
+        if(methodCode.length() > 0){
+            if(HeuristicsUtil.containsAvoidableParticle(methodName.get(0)) && methodName.size() > 1){
+                name = StringUtils.join(methodName.subList(1,methodName.size()), "");
+                final char[] auxCharArray = name.toCharArray();
+                auxCharArray[0] = Character.toLowerCase(auxCharArray[0]);
+                return new String(auxCharArray);
+            }
+        }
+        return methodCode;
+    }
+
+    public void addVariableInformation(Map<String, Map<VariableReference, String>> information){
+        methodNames = information.get("MethodNames");
+        argumentNames = information.get("ArgumentNames");
+    }
+
+}

--- a/client/src/main/java/org/evosuite/testcase/variable/name/TypeBasedVariableNameStrategy.java
+++ b/client/src/main/java/org/evosuite/testcase/variable/name/TypeBasedVariableNameStrategy.java
@@ -19,36 +19,19 @@ public class TypeBasedVariableNameStrategy extends AbstractVariableNameStrategy 
 
     @Override
     public String createNameForVariable(VariableReference var) {
+        String variableName = getPlainNameForVariable(var);
+        return getIndexIncludingFirstAppearance(variableName);
+    }
+
+    public String getPlainNameForVariable(VariableReference var){
+        String className = var.getSimpleClassName();
+        String variableName;
         if (var instanceof ArrayReference) {
-            String className = var.getSimpleClassName();
-            // int num = 0;
-            // for (VariableReference otherVar : variableNames.keySet()) {
-            // if (!otherVar.equals(var)
-            // && otherVar.getVariableClass().equals(var.getVariableClass()))
-            // num++;
-            // }
-            String variableName = className.substring(0, 1).toLowerCase()
+            variableName = className.substring(0, 1).toLowerCase()
                     + className.substring(1) + "Array";
             variableName = variableName.replace('.', '_').replace("[]", "");
-
-            if (!nextIndices.containsKey(variableName)) {
-                nextIndices.put(variableName, 0);
-            }
-
-            int index = nextIndices.get(variableName);
-            nextIndices.put(variableName, index + 1);
-
-            variableName += index;
-
-            return variableName;
         } else {
-            String className = var.getSimpleClassName();
-            // int num = 0;
-            // for (VariableReference otherVar : variableNames.keySet()) {
-            // if (otherVar.getVariableClass().equals(var.getVariableClass()))
-            // num++;
-            // }
-            String variableName = className.substring(0, 1).toLowerCase()
+            variableName = className.substring(0, 1).toLowerCase()
                     + className.substring(1);
             if (variableName.contains("[]")) {
                 variableName = variableName.replace("[]", "Array");
@@ -61,19 +44,30 @@ public class TypeBasedVariableNameStrategy extends AbstractVariableNameStrategy 
             // if (numObjectsOfType > 1 || className.equals(variableName)) {
             if (CharUtils.isAsciiNumeric(variableName.charAt(variableName.length() - 1)))
                 variableName += "_";
-
-            if (!nextIndices.containsKey(variableName)) {
-                nextIndices.put(variableName, 0);
-            }
-
-            int index = nextIndices.get(variableName);
-            nextIndices.put(variableName, index + 1);
-
-            variableName += index;
             // }
 
-            return variableName;
         }
+        return variableName;
+    }
+
+    /**
+     * Returns the variable name + the number of repetitions counting from 0.
+     * i.e. If the variable appears only once in the test, it is named as variable0.
+     *
+     * Mainly used for Type-Based Renaming Strategy (traditional naming in EvoSuite).
+     *
+     * @return String
+     */
+    private String getIndexIncludingFirstAppearance(String variableName) {
+        if (!nextIndices.containsKey(variableName)) {
+            nextIndices.put(variableName, 0);
+        }
+        int index = nextIndices.get(variableName);
+        nextIndices.put(variableName, index + 1);
+        return variableName += index;
+    }
+    public void addVariableInformation(Map<String, Map<VariableReference, String>> information){
+        //If needed any information about types
     }
 
 }

--- a/client/src/main/java/org/evosuite/testcase/variable/name/VariableNameStrategy.java
+++ b/client/src/main/java/org/evosuite/testcase/variable/name/VariableNameStrategy.java
@@ -3,6 +3,7 @@ package org.evosuite.testcase.variable.name;
 import org.evosuite.testcase.variable.VariableReference;
 
 import java.util.Collection;
+import java.util.Map;
 import java.util.Optional;
 
 /**
@@ -38,5 +39,11 @@ public interface VariableNameStrategy {
      * @return The collection of variable names.
      */
     Collection<String> getVariableNames();
+
+    /**
+     * Allows to add information on dictionaries for variable naming
+     */
+    void addVariableInformation(Map<String, Map<VariableReference, String>> information);
+
 
 }

--- a/client/src/main/java/org/evosuite/testcase/variable/name/VariableNameStrategyFactory.java
+++ b/client/src/main/java/org/evosuite/testcase/variable/name/VariableNameStrategyFactory.java
@@ -24,7 +24,11 @@ public class VariableNameStrategyFactory {
     public static VariableNameStrategy get(Properties.VariableNamingStrategy identifierNamingStrategy) {
         if (Properties.VariableNamingStrategy.TYPE_BASED.equals(identifierNamingStrategy)) {
             return new TypeBasedVariableNameStrategy();
-        } else {
+        }
+        if (Properties.VariableNamingStrategy.HEURISTICS_BASED.equals(identifierNamingStrategy)) {
+            return new HeuristicsVariableNameStrategy();
+        }
+        else {
             throw new IllegalArgumentException(String.format("Unknown variable naming strategy: %s", identifierNamingStrategy));
         }
     }
@@ -42,6 +46,13 @@ public class VariableNameStrategyFactory {
 
     private VariableNameStrategyFactory() {
         // Nothing to do here
+    }
+
+    public static boolean gatherInformation(){
+        if (Properties.VariableNamingStrategy.HEURISTICS_BASED.equals(Properties.VARIABLE_NAMING_STRATEGY)) {
+            return true;
+        }
+        return false;
     }
 
 }

--- a/client/src/test/java/org/evosuite/utils/generic/Person.java
+++ b/client/src/test/java/org/evosuite/utils/generic/Person.java
@@ -1,0 +1,26 @@
+package org.evosuite.utils.generic;
+/**
+ * Simple test class of simple setters and getters.
+ * Used for testing variable name generation
+ */
+public class Person {
+    String name;
+    Long id;
+    int age;
+    Person () {
+    }
+    Person (String name, Long id) {
+        this.name = name;
+        this.id = id;
+    }
+    public void setId(long id) {this.id = id;}
+    public void setName(String name) {this.name = name;}
+    public void setAge(int actualAge) {this.age = actualAge;}
+    public String getName() { return name; }
+    public Long getId() { return id; }
+    public int getAge() { return age; }
+
+    public boolean isAdult() { return age>=18; }
+    public int getFixedId() {return 18;}
+}
+


### PR DESCRIPTION
Hi! This small PR proposes a new mode of using methods and arguments information (obtained via reflection) for naming variables in EvoSuite-generated tests. 

Currently, the variable naming is based on the variable type with an index number indicating the number of repetitions the name presents. To improve readability this change proposes using little heuristics on the `TestCodeVisitor` class to gather code information and rename variables.  Consider the following examples of `test3`, The first one uses `linkedList0` and `linkedList1` for naming two variables sent as arguments of the `BookStore` class.
```
  public void test3()  throws Throwable  {
      LinkedList<Book> linkedList0 = new LinkedList<Book>();
      LinkedList<Author> linkedList1 = new LinkedList<Author>();
      BookStore bookStore0 = new BookStore(linkedList0, linkedList1);
     ...
  }
```

In this case, we propose to use information about the names of the arguments in the `BookStore` declaration to give more meaningful names (related to the class under test) as seen in the following version of `test3`:

```
public void test3()  throws Throwable  {
      LinkedList<Book> books = new LinkedList<Book>();
      LinkedList<Author> authors = new LinkedList<Author>();
      BookStore bookStore = new BookStore(books, authors);
     ...
  }
```
Our little heuristics implemented in this PR include using method argument names, and method names (+ a little modification on the first words of the suggested name). Please let us know your thoughts/suggestions about it!

To test the additions in this PR, change the attribute `VariableNamingStrategy` in the `Properties` class to: 
```
@Parameter(key = "variable_naming_strategy", group = "Output", description = "What strategy to use to name variables for tests")
public static VariableNamingStrategy VARIABLE_NAMING_STRATEGY = VariableNamingStrategy.HEURISTICS_BASED;
```

Then, compile to obtain the `jar` file. For generating tests, you must compile the project under test with the option `-parameters` configured for `javac`, this is used to obtain the methods argument names by reflection. You can configure this option in your IDE (Settings > Build, Execution, Deployment > Compiler> Java Compiler > Additional compile line parameters) in IntelliJ)or the `pom.xml` file in Maven.