### PR TITLE
JavaExecCmdUtil: use `Paths.get` to join file paths

### DIFF
--- a/runtime/src/main/java/org/evosuite/runtime/util/JavaExecCmdUtil.java
+++ b/runtime/src/main/java/org/evosuite/runtime/util/JavaExecCmdUtil.java
@@ -20,6 +20,7 @@
 package org.evosuite.runtime.util;
 
 import java.io.File;
+import java.nio.file.Paths;
 import java.util.Optional;
 
 /**
@@ -45,19 +46,14 @@ public class JavaExecCmdUtil {
      * @apiNote under maven java.home property is ${JAVA_HOME}/jre/bin/java
      */
     public static String getJavaBinExecutablePath(final boolean isFullOriginalJavaExecRequired) {
-        final String separator = System.getProperty("file.separator");
-        final String JAVA_CMD =
-                System.getProperty("java.home") + separator + "bin" + separator + "java";
+        final String JAVA_CMD = Paths.get(System.getProperty("java.home"), "bin", "java").toString();
 
         return getJavaHomeEnv()
                 .map(javaHomeEnvVar ->
-                        new File(
-                                javaHomeEnvVar + File.separatorChar + "bin" + File.separatorChar + "java" +
-                                        getOsName()
-                                                .filter(osName -> osName.toLowerCase().contains("windows"))
-                                                .map(osName -> ".exe")
-                                                .orElse("")
-                        )
+                     Paths.get(javaHomeEnvVar, "bin", "java", getOsName()
+                               .filter(osName -> osName.toLowerCase().contains("windows"))
+                               .map(osName -> ".exe")
+                               .orElse("")).toFile()
                 )
                 .filter(File::exists)
                 .map(File::getPath)

--- a/runtime/src/test/java/org/evosuite/runtime/util/JavaExecCmdUtilUnixTest.java
+++ b/runtime/src/test/java/org/evosuite/runtime/util/JavaExecCmdUtilUnixTest.java
@@ -19,6 +19,7 @@
  */
 package org.evosuite.runtime.util;
 
+import java.nio.file.Paths;
 import org.apache.commons.lang3.StringUtils;
 import org.hamcrest.core.IsEqual;
 import org.junit.Before;
@@ -100,7 +101,7 @@ public class JavaExecCmdUtilUnixTest {
                             // set correct java_home and get real path to java
                             environmentVariables.set("JAVA_HOME", JAVA_HOME_SYSTEM);
                             assertThat(JavaExecCmdUtil.getJavaBinExecutablePath(),
-                                    IsEqual.equalTo(JAVA_HOME_SYSTEM + SEPARATOR + "bin" + SEPARATOR + "java"));
+                                       IsEqual.equalTo(Paths.get(JAVA_HOME_SYSTEM, "bin", "java").toString()));
                         }
                 );
     }


### PR DESCRIPTION
Instead of relying on the values of the retrieved variables correctly handling trailing slashes, simply use the `Paths` utility methods to combine directory/path objects.