### PR TITLE
Support java 17

### DIFF
--- a/client/pom.xml
+++ b/client/pom.xml
@@ -37,6 +37,11 @@
 		</dependency>
 
         <!-- Third-party modules -->
+        <dependency>
+            <groupId>org.burningwave</groupId>
+            <artifactId>core</artifactId>
+            <version>12.62.7</version>
+        </dependency>
 
         <dependency>
             <groupId>junit</groupId>

--- a/client/src/main/java/org/evosuite/TestSuiteGenerator.java
+++ b/client/src/main/java/org/evosuite/TestSuiteGenerator.java
@@ -19,6 +19,7 @@
  */
 package org.evosuite;
 
+import org.burningwave.core.assembler.StaticComponentContainer;
 import org.evosuite.Properties.AssertionStrategy;
 import org.evosuite.Properties.Criterion;
 import org.evosuite.Properties.TestFactory;
@@ -85,6 +86,9 @@ public class TestSuiteGenerator {
 
 
     private void initializeTargetClass() throws Throwable {
+        // opens all modules by invoking addExportsToAll0
+        StaticComponentContainer.Modules.exportAllToAll();
+
         String cp = ClassPathHandler.getInstance().getTargetProjectClasspath();
 
         // Generate inheritance tree and call graph *before* loading the CUT

--- a/pom.xml
+++ b/pom.xml
@@ -389,6 +389,12 @@
             </dependency>
 
             <dependency>
+                <groupId>org.burningwave</groupId>
+                <artifactId>core</artifactId>
+                <version>12.62.7</version>
+            </dependency>
+
+            <dependency>
                 <!-- BSD -->
                 <groupId>com.thoughtworks.xstream</groupId>
                 <artifactId>xstream</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -349,31 +349,31 @@
                 <!-- Adhoc license, copyright holder is INRIA -->
                 <groupId>org.ow2.asm</groupId>
                 <artifactId>asm</artifactId>
-                <version>9.2</version>
+                <version>9.5</version>
             </dependency>
             <dependency>
                 <!-- Adhoc license, copyright holder is INRIA -->
                 <groupId>org.ow2.asm</groupId>
                 <artifactId>asm-commons</artifactId>
-                <version>9.2</version>
+                <version>9.5</version>
             </dependency>
             <dependency>
                 <!-- Adhoc license, copyright holder is INRIA -->
                 <groupId>org.ow2.asm</groupId>
                 <artifactId>asm-tree</artifactId>
-                <version>9.2</version>
+                <version>9.5</version>
             </dependency>
             <dependency>
                 <!-- Adhoc license, copyright holder is INRIA -->
                 <groupId>org.ow2.asm</groupId>
                 <artifactId>asm-analysis</artifactId>
-                <version>9.2</version>
+                <version>9.5</version>
             </dependency>
             <dependency>
                 <!-- Adhoc license, copyright holder is INRIA -->
                 <groupId>org.ow2.asm</groupId>
                 <artifactId>asm-util</artifactId>
-                <version>9.2</version>
+                <version>9.5</version>
             </dependency>
             <dependency>
                 <!-- Apache 2 -->
@@ -398,7 +398,7 @@
                 <!-- BSD -->
                 <groupId>com.thoughtworks.xstream</groupId>
                 <artifactId>xstream</artifactId>
-                <version>1.4.18</version>
+                <version>1.4.20</version>
             </dependency>
             <dependency>
                 <!-- Apache 2 -->

--- a/runtime/pom.xml
+++ b/runtime/pom.xml
@@ -47,6 +47,11 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
+            <groupId>org.burningwave</groupId>
+            <artifactId>core</artifactId>
+            <version>12.62.7</version>
+        </dependency>
+        <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
             <scope>provided</scope>

--- a/runtime/src/main/java/org/evosuite/runtime/classhandling/JDKClassResetter.java
+++ b/runtime/src/main/java/org/evosuite/runtime/classhandling/JDKClassResetter.java
@@ -19,6 +19,7 @@
  */
 package org.evosuite.runtime.classhandling;
 
+import org.burningwave.core.assembler.StaticComponentContainer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -44,8 +45,9 @@ public class JDKClassResetter {
      * Save current state of all JDK static fields we are going te reset later on
      */
     public static void init() {
-
         try {
+            // opens all modules by invoking addExportsToAll0
+            StaticComponentContainer.Modules.exportAllToAll();
             Field field = RenderingHints.Key.class.getDeclaredField("identitymap");
             field.setAccessible(true);
             renderingHintsKeyIdentityMap = (Map) field.get(null);


### PR DESCRIPTION
Hello!

I tried to run evosuite with Java 17. But it failed due to java modules error: `module java.base does not "opens java.util" to unnamed module`.

I added a library that supports opening models in runtime and updated xstream and asm versions. I also tried to add `add-opens` to jar manifest, but  that didn't help. This solution is maybe not so good because it opens all modules,
maybe we should choose a set of modules and only open them.

It now at least works on java 17, but maybe we need to update the instrumentation too. I'm not familiar with the evosuite instrumentation, but if I can help support java 17 please let me know what I should do ;)
