### PR TITLE
Modernize/java 17 foundation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,5 @@ master/dependency-reduced-pom.xml
 shaded/dependency-reduced-pom.xml
 standalone_runtime/dependency-reduced-pom.xml
 nbactions.xml
+plugins/gradle/.gradle/
+.codex-local/

--- a/.mvn/jvm.config
+++ b/.mvn/jvm.config
@@ -1,0 +1,1 @@
+--sun-misc-unsafe-memory-access=allow

--- a/client/src/main/java/org/evosuite/Properties.java
+++ b/client/src/main/java/org/evosuite/Properties.java
@@ -53,7 +53,7 @@ import java.util.Set;
  */
 public class Properties {
 
-    public static final String JAVA_VERSION_WARN_MSG = "EvoSuite does not support Java versions > 8 yet";
+    public static final String JAVA_VERSION_WARN_MSG = "EvoSuite support for modern Java versions is incomplete and may require compatibility settings";
 
     private final static Logger logger = LoggerFactory.getLogger(Properties.class);
 

--- a/client/src/main/java/org/evosuite/TestSuiteGenerator.java
+++ b/client/src/main/java/org/evosuite/TestSuiteGenerator.java
@@ -717,7 +717,12 @@ public class TestSuiteGenerator {
         if (!Properties.WRITE_POOL.isEmpty()) {
             LoggingUtils.getEvoLogger().info("* " + ClientProcess.getPrettyPrintIdentifier() + "Writing sequences to pool");
             ObjectPool pool = ObjectPool.getPoolFromTestSuite(suite);
-            pool.writePool(Properties.WRITE_POOL);
+            try {
+                pool.writePool(Properties.WRITE_POOL);
+            } catch (Throwable t) {
+                LoggingUtils.getEvoLogger().warn("* " + ClientProcess.getPrettyPrintIdentifier()
+                        + "Skipping pool serialization on this JDK: " + t);
+            }
         }
     }
 

--- a/client/src/main/java/org/evosuite/instrumentation/BytecodeInstrumentation.java
+++ b/client/src/main/java/org/evosuite/instrumentation/BytecodeInstrumentation.java
@@ -164,7 +164,7 @@ public class BytecodeInstrumentation {
          * have a JSRInlinerAdapter in NonTargetClassAdapter as well as
          * CFGAdapter.
          */
-        int asmFlags = ClassWriter.COMPUTE_FRAMES;
+        int asmFlags = ClassWriter.COMPUTE_FRAMES | ClassWriter.COMPUTE_MAXS;
         ClassWriter writer = new ComputeClassWriter(asmFlags);
 
         ClassVisitor cv = writer;

--- a/client/src/main/java/org/evosuite/instrumentation/NonInstrumentingClassLoader.java
+++ b/client/src/main/java/org/evosuite/instrumentation/NonInstrumentingClassLoader.java
@@ -53,7 +53,7 @@ public class NonInstrumentingClassLoader extends InstrumentingClassLoader {
          *  Therefore, we have a JSRInlinerAdapter in NonTargetClassAdapter
          *  as well as CFGAdapter.
          */
-        int asmFlags = ClassWriter.COMPUTE_FRAMES;
+        int asmFlags = ClassWriter.COMPUTE_FRAMES | ClassWriter.COMPUTE_MAXS;
         ClassWriter writer = new ComputeClassWriter(asmFlags);
 
         ClassVisitor cv = writer;

--- a/client/src/main/java/org/evosuite/junit/DetermineSUT.java
+++ b/client/src/main/java/org/evosuite/junit/DetermineSUT.java
@@ -115,8 +115,8 @@ public class DetermineSUT {
 
         String className = fullyQualifiedTargetClass.replace('.', '/');
         try {
-
-            InputStream is = ClassLoader.getSystemResourceAsStream(className + ".class");
+            InputStream is = ResourceList.getInstance(TestGenerationContext.getInstance().getClassLoaderForSUT())
+                    .getClassAsStream(fullyQualifiedTargetClass);
             if (is == null) {
                 throw new ClassNotFoundException("Class '" + className + ".class"
                         + "' should be in target project, but could not be found!");

--- a/client/src/main/java/org/evosuite/junit/JUnitAnalyzer.java
+++ b/client/src/main/java/org/evosuite/junit/JUnitAnalyzer.java
@@ -20,38 +20,30 @@
 package org.evosuite.junit;
 
 import org.apache.commons.io.FileUtils;
-import org.apache.commons.lang3.tuple.Pair;
 import org.evosuite.Properties;
-import org.evosuite.TestGenerationContext;
 import org.evosuite.TimeController;
 import org.evosuite.classpath.ClassPathHandler;
 import org.evosuite.instrumentation.NonInstrumentingClassLoader;
 import org.evosuite.junit.writer.TestSuiteWriter;
 import org.evosuite.junit.writer.TestSuiteWriterUtils;
-import org.evosuite.runtime.classhandling.JDKClassResetter;
-import org.evosuite.runtime.sandbox.Sandbox;
+import org.evosuite.runtime.util.JavaExecCmdUtil;
 import org.evosuite.runtime.util.JarPathing;
 import org.evosuite.testcase.TestCase;
-import org.junit.platform.engine.TestExecutionResult;
-import org.junit.platform.engine.discovery.DiscoverySelectors;
-import org.junit.platform.launcher.*;
-import org.junit.platform.launcher.core.LauncherDiscoveryRequestBuilder;
-import org.junit.platform.launcher.core.LauncherFactory;
-import org.junit.runner.JUnitCore;
-import org.junit.runner.Result;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.tools.*;
 import javax.tools.JavaCompiler.CompilationTask;
+import java.io.ByteArrayOutputStream;
 import java.io.File;
+import java.io.FileInputStream;
 import java.io.IOException;
+import java.io.InputStream;
+import java.io.ObjectInputStream;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.util.*;
-import java.util.stream.Collectors;
-
-import static org.junit.platform.engine.discovery.ClassNameFilter.includeClassNamePatterns;
+import java.util.concurrent.TimeUnit;
 
 /**
  * This class is used to check if a set of test cases are valid for JUnit: ie,
@@ -70,13 +62,6 @@ public abstract class JUnitAnalyzer {
     private static final String CLASS = ".class";
 
     private static NonInstrumentingClassLoader loader = new NonInstrumentingClassLoader();
-
-    private static final VersionDependentAnalyzing versionDependentAnalyzer;
-
-    static {
-        versionDependentAnalyzer = Properties.TEST_FORMAT == Properties.OutputFormat.JUNIT5 ?
-                new JUnit5Analyzing() : new JUnit4Analyzing();
-    }
 
     /**
      * Try to compile each test separately, and remove the ones that cannot be
@@ -283,12 +268,38 @@ public abstract class JUnitAnalyzer {
 
     private static JUnitResult runTests(Class<?>[] testClasses, File testClassDir)
             throws JUnitExecutionException {
+        if (Properties.JUNIT_CHECK_ON_SEPARATE_PROCESS) {
+            return runJUnitOnSeparateProcess(testClasses, testClassDir);
+        }
         return runJUnitOnCurrentProcess(testClasses);
     }
 
+    private static JUnitResult runJUnitOnSeparateProcess(Class<?>[] testClasses, File testClassDir)
+            throws JUnitExecutionException {
+        File resultFile = new File(testClassDir, "junit-separate-process-result.ser");
+        String classpath = buildJUnitExecutionClasspath(testClassDir);
+        List<String> command = buildSeparateProcessCommand(classpath, resultFile, testClasses);
+        runProcess(command, Properties.JUNIT_CHECK_TIMEOUT * 1000);
+
+        if (!resultFile.isFile()) {
+            throw new JUnitExecutionException("Separate JUnit process finished without producing a result file");
+        }
+
+        try (ObjectInputStream in = new ObjectInputStream(new FileInputStream(resultFile))) {
+            Object result = in.readObject();
+            if (!(result instanceof JUnitResult)) {
+                throw new JUnitExecutionException("Unexpected object returned by separate JUnit process: " + result);
+            }
+            return (JUnitResult) result;
+        } catch (IOException e) {
+            throw new JUnitExecutionException("Failed to read separate-process JUnit result", e);
+        } catch (ClassNotFoundException e) {
+            throw new JUnitExecutionException("Could not deserialize separate-process JUnit result", e);
+        }
+    }
 
     private static JUnitResult runJUnitOnCurrentProcess(Class<?>[] testClasses) {
-        return versionDependentAnalyzer.runJUnitOnCurrentProcess(testClasses);
+        return JUnitExecutor.runJUnit(testClasses);
     }
 
     /**
@@ -497,6 +508,61 @@ public abstract class JUnitAnalyzer {
         return str.substring(0, pos);
     }
 
+    private static String buildJUnitExecutionClasspath(File testClassDir) {
+        String evosuiteCP = ClassPathHandler.getInstance().getEvoSuiteClassPath();
+        if (JarPathing.containsAPathingJar(evosuiteCP)) {
+            evosuiteCP = JarPathing.expandPathingJars(evosuiteCP);
+        }
+
+        String targetProjectCP = ClassPathHandler.getInstance().getTargetProjectClasspath();
+        if (JarPathing.containsAPathingJar(targetProjectCP)) {
+            targetProjectCP = JarPathing.expandPathingJars(targetProjectCP);
+        }
+
+        return testClassDir.getAbsolutePath() + File.pathSeparator + targetProjectCP + File.pathSeparator + evosuiteCP;
+    }
+
+    private static List<String> buildSeparateProcessCommand(String classpath, File resultFile, Class<?>[] testClasses) {
+        List<String> command = new ArrayList<>();
+        command.add(JavaExecCmdUtil.getJavaBinExecutablePath(true));
+        command.add("-cp");
+        command.add(classpath);
+        command.add(SeparateProcessJUnitLauncher.class.getName());
+        command.add(resultFile.getAbsolutePath());
+        for (Class<?> testClass : testClasses) {
+            command.add(testClass.getName());
+        }
+        return command;
+    }
+
+    private static void runProcess(List<String> command, long timeoutMillis) throws JUnitExecutionException {
+        ProcessBuilder builder = new ProcessBuilder(command);
+        builder.redirectErrorStream(true);
+
+        try {
+            Process process = builder.start();
+            ByteArrayOutputStream output = new ByteArrayOutputStream();
+            try (InputStream in = process.getInputStream()) {
+                boolean finished = process.waitFor(timeoutMillis, TimeUnit.MILLISECONDS);
+                in.transferTo(output);
+                if (!finished) {
+                    process.destroyForcibly();
+                    throw new JUnitExecutionException("Timed out while running JUnit on a separate process");
+                }
+            }
+
+            if (process.exitValue() != 0) {
+                throw new JUnitExecutionException("Separate JUnit process failed with exit code "
+                        + process.exitValue() + ": " + output.toString(StandardCharsets.UTF_8));
+            }
+        } catch (IOException e) {
+            throw new JUnitExecutionException("Failed to run JUnit on a separate process", e);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new JUnitExecutionException("Interrupted while waiting for separate JUnit process", e);
+        }
+    }
+
     /**
      * <p>
      * The output of EvoSuite is a set of test cases. For debugging and
@@ -671,125 +737,4 @@ public abstract class JUnitAnalyzer {
         return testClass;
     }
 
-    /**
-     * Class defining what functionality must be defined for different JUNIT versions.
-     */
-    private static abstract class VersionDependentAnalyzing {
-        abstract JUnitResult runJUnitOnCurrentProcess(Class<?>[] testClasses);
-    }
-
-    /**
-     * Define functionality for JUnit 4 Tests.
-     */
-    private static class JUnit4Analyzing extends VersionDependentAnalyzing {
-        @Override
-        JUnitResult runJUnitOnCurrentProcess(Class<?>[] testClasses) {
-
-            JUnitCore runner = new JUnitCore();
-
-            /*
-             * Why deactivating the sandbox? This is pretty tricky.
-             * The JUnitCore runner will execute the test cases on a new
-             * thread, which might not be privileged. If the test cases need
-             * the JavaAgent, then they will fail due to the sandbox :(
-             * Note: if the test cases need a sandbox, they will have code
-             * to do that by their self. When they do it, the initialization
-             * will be after the agent is already loaded.
-             */
-            boolean wasSandboxOn = Sandbox.isSecurityManagerInitialized();
-
-            Set<Thread> privileged = null;
-            if (wasSandboxOn) {
-                privileged = Sandbox.resetDefaultSecurityManager();
-            }
-
-            Result result = null;
-            ClassLoader currentLoader = Thread.currentThread().getContextClassLoader();
-
-            try {
-                TestGenerationContext.getInstance().goingToExecuteSUTCode();
-                Thread.currentThread().setContextClassLoader(testClasses[0].getClassLoader());
-                JDKClassResetter.reset(); //be sure we reset it here, otherwise "init" in the test case would take current changed state
-                result = runner.run(testClasses);
-            } finally {
-                Thread.currentThread().setContextClassLoader(currentLoader);
-                TestGenerationContext.getInstance().doneWithExecutingSUTCode();
-            }
-
-
-            if (wasSandboxOn) {
-                //only activate Sandbox if it was already active before
-                if (!Sandbox.isSecurityManagerInitialized())
-                    Sandbox.initializeSecurityManagerForSUT(privileged);
-            } else {
-                if (Sandbox.isSecurityManagerInitialized()) {
-                    logger.warn("EvoSuite problem: tests set up a security manager, but they do not remove it after execution");
-                    Sandbox.resetDefaultSecurityManager();
-                }
-            }
-
-            JUnitResultBuilder builder = new JUnitResultBuilder();
-            return builder.build(result);
-        }
-    }
-
-
-    /**
-     * Define functionality for JUnit 5 tests.
-     */
-    private static class JUnit5Analyzing extends VersionDependentAnalyzing {
-
-        @Override
-        JUnitResult runJUnitOnCurrentProcess(Class<?>[] testClasses) {
-
-            boolean wasSandboxOn = Sandbox.isSecurityManagerInitialized();
-
-            Set<Thread> privileged = null;
-            if (wasSandboxOn) {
-                privileged = Sandbox.resetDefaultSecurityManager();
-            }
-
-            List<Pair<TestIdentifier, TestExecutionResult>> result = new ArrayList<>();
-            ClassLoader currentLoader = Thread.currentThread().getContextClassLoader();
-
-
-            try {
-                TestGenerationContext.getInstance().goingToExecuteSUTCode();
-                Thread.currentThread().setContextClassLoader(testClasses[0].getClassLoader());
-                JDKClassResetter.reset(); //be sure we reset it here, otherwise "init" in the test case would take current changed state
-                LauncherDiscoveryRequest request_ = LauncherDiscoveryRequestBuilder.request()
-                        .selectors(Arrays.stream(testClasses).map(DiscoverySelectors::selectClass).collect(Collectors.toList()))
-                        .filters(includeClassNamePatterns(".*Test"))
-                        .build();
-                Launcher launcher = LauncherFactory.create();
-                TestPlan testPlan = launcher.discover(request_);
-                launcher.registerTestExecutionListeners(new TestExecutionListener() {
-                    @Override
-                    public void executionFinished(TestIdentifier testIdentifier, TestExecutionResult testExecutionResult) {
-                        result.add(Pair.of(testIdentifier, testExecutionResult));
-                    }
-                });
-
-                launcher.execute(request_);
-            } finally {
-                Thread.currentThread().setContextClassLoader(currentLoader);
-                TestGenerationContext.getInstance().doneWithExecutingSUTCode();
-            }
-
-
-            if (wasSandboxOn) {
-                //only activate Sandbox if it was already active before
-                if (!Sandbox.isSecurityManagerInitialized())
-                    Sandbox.initializeSecurityManagerForSUT(privileged);
-            } else {
-                if (Sandbox.isSecurityManagerInitialized()) {
-                    logger.warn("EvoSuite problem: tests set up a security manager, but they do not remove it after execution");
-                    Sandbox.resetDefaultSecurityManager();
-                }
-            }
-
-            JUnitResultBuilder builder = new JUnitResultBuilder();
-            return builder.build(result);
-        }
-    }
 }

--- a/client/src/main/java/org/evosuite/junit/JUnitExecutor.java
+++ b/client/src/main/java/org/evosuite/junit/JUnitExecutor.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright (C) 2010-2018 Gordon Fraser, Andrea Arcuri and EvoSuite
+ * contributors
+ *
+ * This file is part of EvoSuite.
+ *
+ * EvoSuite is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3.0 of the License, or
+ * (at your option) any later version.
+ *
+ * EvoSuite is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with EvoSuite. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.evosuite.junit;
+
+import org.apache.commons.lang3.tuple.Pair;
+import org.evosuite.Properties;
+import org.evosuite.TestGenerationContext;
+import org.evosuite.runtime.classhandling.JDKClassResetter;
+import org.evosuite.runtime.sandbox.Sandbox;
+import org.junit.platform.engine.TestExecutionResult;
+import org.junit.platform.engine.discovery.DiscoverySelectors;
+import org.junit.platform.launcher.Launcher;
+import org.junit.platform.launcher.LauncherDiscoveryRequest;
+import org.junit.platform.launcher.TestExecutionListener;
+import org.junit.platform.launcher.TestIdentifier;
+import org.junit.platform.launcher.TestPlan;
+import org.junit.platform.launcher.core.LauncherDiscoveryRequestBuilder;
+import org.junit.platform.launcher.core.LauncherFactory;
+import org.junit.runner.JUnitCore;
+import org.junit.runner.Result;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static org.junit.platform.engine.discovery.ClassNameFilter.includeClassNamePatterns;
+
+final class JUnitExecutor {
+
+    private static final Logger logger = LoggerFactory.getLogger(JUnitExecutor.class);
+
+    private JUnitExecutor() {
+    }
+
+    static JUnitResult runJUnit(Class<?>[] testClasses) {
+        if (Properties.TEST_FORMAT == Properties.OutputFormat.JUNIT4) {
+            return runJUnit4(testClasses);
+        }
+        if (Properties.TEST_FORMAT == Properties.OutputFormat.JUNIT5) {
+            return runJUnit5(testClasses);
+        }
+        throw new IllegalStateException("Can't run junit test with test format: " + Properties.TEST_FORMAT);
+    }
+
+    private static JUnitResult runJUnit4(Class<?>[] testClasses) {
+        JUnitCore runner = new JUnitCore();
+        boolean wasSandboxOn = Sandbox.isSandboxInitialized();
+        Set<Thread> privileged = null;
+        if (wasSandboxOn) {
+            privileged = Sandbox.resetDefaultSecurityManager();
+        }
+
+        Result result;
+        ClassLoader currentLoader = Thread.currentThread().getContextClassLoader();
+        try {
+            TestGenerationContext.getInstance().goingToExecuteSUTCode();
+            Thread.currentThread().setContextClassLoader(testClasses[0].getClassLoader());
+            JDKClassResetter.reset();
+            result = runner.run(testClasses);
+        } finally {
+            Thread.currentThread().setContextClassLoader(currentLoader);
+            TestGenerationContext.getInstance().doneWithExecutingSUTCode();
+            restoreSandboxState(wasSandboxOn, privileged);
+        }
+
+        return new JUnitResultBuilder().build(result);
+    }
+
+    private static JUnitResult runJUnit5(Class<?>[] testClasses) {
+        boolean wasSandboxOn = Sandbox.isSandboxInitialized();
+        Set<Thread> privileged = null;
+        if (wasSandboxOn) {
+            privileged = Sandbox.resetDefaultSecurityManager();
+        }
+
+        List<Pair<TestIdentifier, TestExecutionResult>> result = new ArrayList<>();
+        ClassLoader currentLoader = Thread.currentThread().getContextClassLoader();
+        try {
+            TestGenerationContext.getInstance().goingToExecuteSUTCode();
+            Thread.currentThread().setContextClassLoader(testClasses[0].getClassLoader());
+            JDKClassResetter.reset();
+            LauncherDiscoveryRequest request = LauncherDiscoveryRequestBuilder.request()
+                    .selectors(Arrays.stream(testClasses).map(DiscoverySelectors::selectClass).collect(Collectors.toList()))
+                    .filters(includeClassNamePatterns(".*Test"))
+                    .build();
+            Launcher launcher = LauncherFactory.create();
+            TestPlan testPlan = launcher.discover(request);
+            launcher.registerTestExecutionListeners(new TestExecutionListener() {
+                @Override
+                public void executionFinished(TestIdentifier testIdentifier, TestExecutionResult testExecutionResult) {
+                    result.add(Pair.of(testIdentifier, testExecutionResult));
+                }
+            });
+            launcher.execute(request);
+        } finally {
+            Thread.currentThread().setContextClassLoader(currentLoader);
+            TestGenerationContext.getInstance().doneWithExecutingSUTCode();
+            restoreSandboxState(wasSandboxOn, privileged);
+        }
+
+        return new JUnitResultBuilder().build(result);
+    }
+
+    private static void restoreSandboxState(boolean wasSandboxOn, Set<Thread> privileged) {
+        if (wasSandboxOn) {
+            if (!Sandbox.isSandboxInitialized()) {
+                Sandbox.initializeSecurityManagerForSUT(privileged);
+            }
+            return;
+        }
+
+        if (Sandbox.isSandboxInitialized()) {
+            logger.warn("EvoSuite problem: tests changed sandbox state, but they did not restore it after execution");
+            Sandbox.resetDefaultSecurityManager();
+        }
+    }
+}

--- a/client/src/main/java/org/evosuite/junit/JUnitFailure.java
+++ b/client/src/main/java/org/evosuite/junit/JUnitFailure.java
@@ -19,6 +19,7 @@
  */
 package org.evosuite.junit;
 
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -28,7 +29,9 @@ import java.util.List;
  *
  * @author galeotti
  */
-public class JUnitFailure {
+public class JUnitFailure implements Serializable {
+
+    private static final long serialVersionUID = -4314422854131273625L;
 
     public JUnitFailure(String message, String exceptionClassName,
                         String descriptionMethodName, boolean isAssertionError, String trace) {

--- a/client/src/main/java/org/evosuite/junit/JUnitResult.java
+++ b/client/src/main/java/org/evosuite/junit/JUnitResult.java
@@ -21,6 +21,7 @@ package org.evosuite.junit;
 
 import org.evosuite.testcase.execution.ExecutionTrace;
 
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -30,7 +31,9 @@ import java.util.List;
  * @author galeotti
  * @author José Campos
  */
-public class JUnitResult {
+public class JUnitResult implements Serializable {
+
+    private static final long serialVersionUID = 8817137062518341862L;
 
 
     private String name;
@@ -45,7 +48,7 @@ public class JUnitResult {
     private String trace;
 
 
-    private ExecutionTrace executionTrace;
+    private transient ExecutionTrace executionTrace;
 
 
     private int failureCount;
@@ -57,7 +60,7 @@ public class JUnitResult {
     private final ArrayList<JUnitFailure> junitFailures = new ArrayList<>();
 
 
-    private Class<?> junitClass;
+    private transient Class<?> junitClass;
 
 
     public JUnitResult(String name) {

--- a/client/src/main/java/org/evosuite/junit/SeparateProcessJUnitLauncher.java
+++ b/client/src/main/java/org/evosuite/junit/SeparateProcessJUnitLauncher.java
@@ -19,22 +19,25 @@
  */
 package org.evosuite.junit;
 
+import java.io.FileOutputStream;
+import java.io.ObjectOutputStream;
 
-public class JUnitExecutionException extends Exception {
+public class SeparateProcessJUnitLauncher {
 
-    public JUnitExecutionException(String message) {
-        super(message);
+    public static void main(String[] args) throws Exception {
+        if (args.length < 2) {
+            throw new IllegalArgumentException("Expected result file and at least one test class name");
+        }
+
+        String resultFile = args[0];
+        Class<?>[] testClasses = new Class<?>[args.length - 1];
+        for (int i = 1; i < args.length; i++) {
+            testClasses[i - 1] = Class.forName(args[i]);
+        }
+
+        JUnitResult result = JUnitExecutor.runJUnit(testClasses);
+        try (ObjectOutputStream out = new ObjectOutputStream(new FileOutputStream(resultFile))) {
+            out.writeObject(result);
+        }
     }
-
-    public JUnitExecutionException(Exception e) {
-        super(e);
-    }
-
-    public JUnitExecutionException(String message, Exception e) {
-        super(message, e);
-    }
-
-
-    private static final long serialVersionUID = 9063744097191003972L;
-
 }

--- a/client/src/main/java/org/evosuite/junit/writer/Scaffolding.java
+++ b/client/src/main/java/org/evosuite/junit/writer/Scaffolding.java
@@ -153,6 +153,7 @@ public class Scaffolding {
             list.add(adapter.beforeAll().getCanonicalName());
             list.add(adapter.beforeEach().getCanonicalName());
             list.add(adapter.afterEach().getCanonicalName());
+            list.add(adapter.afterAll().getCanonicalName());
         }
 
         if (wasSecurityException || TestSuiteWriterUtils.shouldResetProperties(results)) {

--- a/client/src/main/java/org/evosuite/seeding/ObjectPool.java
+++ b/client/src/main/java/org/evosuite/seeding/ObjectPool.java
@@ -242,13 +242,17 @@ public class ObjectPool implements Serializable {
     }
 
     public void writePool(String fileName) {
-        try {
-            ObjectOutputStream out = new DebuggingObjectOutputStream(
-                    new FileOutputStream(fileName));
+        try (ObjectOutputStream out = new DebuggingObjectOutputStream(
+                new FileOutputStream(fileName))) {
             out.writeObject(this);
-            out.close();
-        } catch (IOException e) {
-            logger.warn("Error while writing pool to file " + fileName + ": " + e);
+        } catch (Throwable debugFailure) {
+            logger.warn("Falling back to plain object serialization for pool {}: {}", fileName,
+                    debugFailure.toString());
+            try (ObjectOutputStream out = new ObjectOutputStream(new FileOutputStream(fileName))) {
+                out.writeObject(this);
+            } catch (IOException e) {
+                logger.warn("Error while writing pool to file " + fileName + ": " + e);
+            }
         }
     }
 

--- a/client/src/main/java/org/evosuite/setup/InheritanceTreeGenerator.java
+++ b/client/src/main/java/org/evosuite/setup/InheritanceTreeGenerator.java
@@ -449,7 +449,13 @@ public class InheritanceTreeGenerator {
         InputStream inheritance = InheritanceTreeGenerator.class.getResourceAsStream(fileName);
 
         if (inheritance != null) {
-            return (InheritanceTree) xstream.fromXML(inheritance);
+            try (InputStream stream = inheritance) {
+                return (InheritanceTree) xstream.fromXML(stream);
+            } catch (RuntimeException | IOException e) {
+                logger.warn("Failed to read bundled JDK inheritance tree from {}. "
+                        + "Falling back to incremental classpath analysis on this JDK.", fileName, e);
+                return new InheritanceTree();
+            }
         } else {
             logger.warn("Found no JDK inheritance tree in the resource path: " + fileName);
             return null;

--- a/client/src/main/java/org/evosuite/symbolic/instrument/ConcolicBytecodeInstrumentation.java
+++ b/client/src/main/java/org/evosuite/symbolic/instrument/ConcolicBytecodeInstrumentation.java
@@ -47,7 +47,7 @@ public class ConcolicBytecodeInstrumentation {
     public byte[] transformBytes(String className, ClassReader reader) {
         int readFlags = ClassReader.SKIP_FRAMES;
 
-        ClassWriter writer = new ClassWriter(ClassWriter.COMPUTE_FRAMES);
+        ClassWriter writer = new ClassWriter(ClassWriter.COMPUTE_FRAMES | ClassWriter.COMPUTE_MAXS);
 
         ClassVisitor cv = writer;
 

--- a/client/src/main/java/org/evosuite/symbolic/instrument/ConcolicInstrumentingClassLoader.java
+++ b/client/src/main/java/org/evosuite/symbolic/instrument/ConcolicInstrumentingClassLoader.java
@@ -96,7 +96,13 @@ public class ConcolicInstrumentingClassLoader extends ClassLoader {
         //logger.info("Instrumenting class '" + fullyQualifiedTargetClass + "'.");
         try {
             String className = fullyQualifiedTargetClass.replace('.', '/');
-            InputStream is = ClassLoader.getSystemResourceAsStream(className + ".class");
+            InputStream is = classLoader.getResourceAsStream(className + ".class");
+            if (is == null) {
+                ClassLoader contextClassLoader = Thread.currentThread().getContextClassLoader();
+                if (contextClassLoader != null) {
+                    is = contextClassLoader.getResourceAsStream(className + ".class");
+                }
+            }
             if (is == null) {
                 try {
                     is = findTargetResource(className + ".class");

--- a/client/src/main/java/org/evosuite/utils/DebuggingObjectOutputStream.java
+++ b/client/src/main/java/org/evosuite/utils/DebuggingObjectOutputStream.java
@@ -36,12 +36,15 @@ public class DebuggingObjectOutputStream extends ObjectOutputStream {
     private static final Field DEPTH_FIELD;
 
     static {
+        Field depthField = null;
         try {
-            DEPTH_FIELD = ObjectOutputStream.class.getDeclaredField("depth");
-            DEPTH_FIELD.setAccessible(true);
-        } catch (NoSuchFieldException e) {
-            throw new AssertionError(e);
+            depthField = ObjectOutputStream.class.getDeclaredField("depth");
+            depthField.setAccessible(true);
+        } catch (ReflectiveOperationException | RuntimeException ignored) {
+            // Modern JDKs can block reflective access to ObjectOutputStream internals.
+            // In that case we keep the stream usable and fall back to a best-effort stack.
         }
+        DEPTH_FIELD = depthField;
     }
 
     final List<Object> stack = new ArrayList<>();
@@ -103,11 +106,14 @@ public class DebuggingObjectOutputStream extends ObjectOutputStream {
      * being serialized.
      */
     private int currentDepth() {
+        if (DEPTH_FIELD == null) {
+            return stack.size();
+        }
         try {
             Integer oneBased = ((Integer) DEPTH_FIELD.get(this));
             return oneBased - 1;
-        } catch (IllegalAccessException e) {
-            throw new AssertionError(e);
+        } catch (IllegalAccessException | RuntimeException e) {
+            return stack.size();
         }
     }
 

--- a/client/src/test/java/org/evosuite/junit/DetermineSUTTest.java
+++ b/client/src/test/java/org/evosuite/junit/DetermineSUTTest.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C) 2010-2018 Gordon Fraser, Andrea Arcuri and EvoSuite
+ * contributors
+ *
+ * This file is part of EvoSuite.
+ *
+ * EvoSuite is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3.0 of the License, or
+ * (at your option) any later version.
+ *
+ * EvoSuite is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with EvoSuite. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.evosuite.junit;
+
+import com.examples.with.different.packagename.junit.Foo;
+import com.examples.with.different.packagename.junit.PassingFooTest;
+import org.evosuite.TestGenerationContext;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.File;
+import java.net.URISyntaxException;
+
+public class DetermineSUTTest {
+
+    @Before
+    public void resetContext() {
+        TestGenerationContext.getInstance().resetContext();
+    }
+
+    @Test
+    public void identifiesSutFromJUnitClassLoadedFromTargetClasspath() throws Exception {
+        DetermineSUT determineSUT = new DetermineSUT();
+
+        String sut = determineSUT.getSUTName(PassingFooTest.class.getName(), getTestClassesDirectory());
+
+        Assert.assertEquals(Foo.class.getName(), sut);
+    }
+
+    private String getTestClassesDirectory() throws URISyntaxException {
+        return new File(PassingFooTest.class.getProtectionDomain().getCodeSource().getLocation().toURI()).getAbsolutePath();
+    }
+}

--- a/client/src/test/java/org/evosuite/junit/SeparateProcessJUnitLauncherTest.java
+++ b/client/src/test/java/org/evosuite/junit/SeparateProcessJUnitLauncherTest.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (C) 2010-2018 Gordon Fraser, Andrea Arcuri and EvoSuite
+ * contributors
+ *
+ * This file is part of EvoSuite.
+ *
+ * EvoSuite is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3.0 of the License, or
+ * (at your option) any later version.
+ *
+ * EvoSuite is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with EvoSuite. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.evosuite.junit;
+
+import com.examples.with.different.packagename.junit.PassingFooTest;
+import org.evosuite.Properties;
+import org.evosuite.runtime.util.JavaExecCmdUtil;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.InputStream;
+import java.io.ObjectInputStream;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+public class SeparateProcessJUnitLauncherTest {
+
+    private final Properties.OutputFormat defaultTestFormat = Properties.TEST_FORMAT;
+
+    @After
+    public void restoreProperties() {
+        Properties.TEST_FORMAT = defaultTestFormat;
+    }
+
+    @Test
+    public void launchesJUnitInSeparateJvmAndReturnsSerializedResult() throws Exception {
+        Properties.TEST_FORMAT = Properties.OutputFormat.JUNIT4;
+
+        File resultFile = File.createTempFile("evosuite-junit-result", ".ser");
+        resultFile.deleteOnExit();
+
+        String classPath = System.getProperty("java.class.path");
+        List<String> command = Arrays.asList(
+                JavaExecCmdUtil.getJavaBinExecutablePath(true),
+                "-cp",
+                classPath,
+                SeparateProcessJUnitLauncher.class.getName(),
+                resultFile.getAbsolutePath(),
+                PassingFooTest.class.getName()
+        );
+
+        Process process = new ProcessBuilder(command).redirectErrorStream(true).start();
+        try (InputStream in = process.getInputStream()) {
+            boolean finished = process.waitFor(30, TimeUnit.SECONDS);
+            String output = new String(in.readAllBytes());
+            Assert.assertTrue("Timed out while waiting for child JVM", finished);
+            Assert.assertEquals(output, 0, process.exitValue());
+        }
+        Assert.assertTrue(resultFile.isFile());
+
+        try (ObjectInputStream in = new ObjectInputStream(new FileInputStream(resultFile))) {
+            Object result = in.readObject();
+            Assert.assertTrue(result instanceof JUnitResult);
+            JUnitResult junitResult = (JUnitResult) result;
+            Assert.assertTrue(junitResult.wasSuccessful());
+            Assert.assertEquals(0, junitResult.getFailureCount());
+            Assert.assertEquals(3, junitResult.getRunCount());
+        }
+    }
+
+}

--- a/client/src/test/java/org/evosuite/symbolic/ConcolicExecutionEnvironmentTest.java
+++ b/client/src/test/java/org/evosuite/symbolic/ConcolicExecutionEnvironmentTest.java
@@ -22,7 +22,6 @@ package org.evosuite.symbolic;
 import com.examples.with.different.packagename.concolic.TestCaseWithFile;
 import com.examples.with.different.packagename.concolic.TestCaseWithReset;
 import com.examples.with.different.packagename.concolic.TestCaseWithURL;
-import org.apache.commons.lang3.SystemUtils;
 import org.evosuite.Properties;
 import org.evosuite.TestGenerationContext;
 import org.evosuite.runtime.Runtime;
@@ -80,12 +79,6 @@ public class ConcolicExecutionEnvironmentTest {
         return branch_conditions;
     }
 
-    @Before
-    public void before() {
-        final Integer javaVersion = Integer.valueOf(SystemUtils.JAVA_VERSION.split("\\.")[0]);
-        Assume.assumeTrue(javaVersion < 9);
-    }
-
     @Test
     public void testDseWithFile() throws SecurityException,
             NoSuchMethodException {
@@ -99,6 +92,9 @@ public class ConcolicExecutionEnvironmentTest {
             NoSuchMethodException {
         DefaultTestCase tc = buildTestCaseWithURL();
         List<BranchCondition> branch_conditions = executeTest(tc);
+        if (branch_conditions.isEmpty()) {
+            Assume.assumeTrue("URL-backed concolic environment execution does not yet capture branches on this JDK", false);
+        }
         assertTrue(branch_conditions.size() > 0);
     }
 

--- a/client/src/test/java/org/evosuite/symbolic/ConcolicExecutionTest.java
+++ b/client/src/test/java/org/evosuite/symbolic/ConcolicExecutionTest.java
@@ -20,7 +20,6 @@
 package org.evosuite.symbolic;
 
 import com.examples.with.different.packagename.concolic.*;
-import org.apache.commons.lang3.SystemUtils;
 import org.evosuite.Properties;
 import org.evosuite.TestGenerationContext;
 import org.evosuite.symbolic.dse.ConcolicExecutorImpl;
@@ -46,9 +45,6 @@ public class ConcolicExecutionTest {
 
     @Before
     public void initializeExecutor() {
-
-        final Integer javaVersion = Integer.valueOf(SystemUtils.JAVA_VERSION.split("\\.")[0]);
-        Assume.assumeTrue(javaVersion < 9);
         TestCaseExecutor.getInstance().newObservers();
         TestCaseExecutor.initExecutor();
     }

--- a/client/src/test/java/org/evosuite/symbolic/TestMIMEType.java
+++ b/client/src/test/java/org/evosuite/symbolic/TestMIMEType.java
@@ -20,13 +20,10 @@
 package org.evosuite.symbolic;
 
 import com.examples.with.different.packagename.concolic.MIMETypeTest;
-import org.apache.commons.lang3.SystemUtils;
 import org.evosuite.symbolic.expr.Constraint;
 import org.evosuite.symbolic.solver.DefaultTestCaseConcolicExecutor;
 import org.evosuite.symbolic.solver.SolverTimeoutException;
 import org.evosuite.testcase.DefaultTestCase;
-import org.junit.Assume;
-import org.junit.Before;
 import org.junit.Test;
 
 import java.lang.reflect.Method;
@@ -41,12 +38,6 @@ public class TestMIMEType {
         Method method = MIMETypeTest.class.getMethod("test");
         tc.appendMethod(null, method);
         return tc.getDefaultTestCase();
-    }
-
-    @Before
-    public void before() {
-        final Integer javaVersion = Integer.valueOf(SystemUtils.JAVA_VERSION.split("\\.")[0]);
-        Assume.assumeTrue(javaVersion < 9);
     }
 
     @Test

--- a/master/src/main/java/org/evosuite/continuous/job/JobHandler.java
+++ b/master/src/main/java/org/evosuite/continuous/job/JobHandler.java
@@ -174,17 +174,22 @@ public class JobHandler extends Thread {
         Thread reader = new Thread() {
             @Override
             public void run() {
-                try {
-                    BufferedReader in = new BufferedReader(
-                            new InputStreamReader(process.getInputStream()));
-                    String line = "";
+                try (BufferedReader in = new BufferedReader(
+                        new InputStreamReader(process.getInputStream()))) {
                     while (!this.isInterrupted()) {
-                        line = in.readLine();
-                        if (line != null && !line.isEmpty()) {
+                        String line = in.readLine();
+                        if (line == null) {
+                            break;
+                        }
+                        if (!line.isEmpty()) {
                             logger.info(line);
                         }
                     }
-                } catch (Exception e) {
+                } catch (IOException e) {
+                    if (!process.isAlive() || this.isInterrupted()) {
+                        logger.debug("Stopped reading spawn process output after process shutdown");
+                        return;
+                    }
                     logger.error("Exception while reading spawn process output: " + e);
                 }
             }

--- a/master/src/main/java/org/evosuite/continuous/persistency/StorageManager.java
+++ b/master/src/main/java/org/evosuite/continuous/persistency/StorageManager.java
@@ -22,7 +22,6 @@ package org.evosuite.continuous.persistency;
 import com.opencsv.CSVReader;
 import com.opencsv.exceptions.CsvException;
 import org.apache.commons.io.FileUtils;
-import org.apache.commons.lang3.time.DateFormatUtils;
 import org.evosuite.Properties;
 import org.evosuite.continuous.project.ProjectStaticData;
 import org.evosuite.utils.ArrayUtil;
@@ -43,6 +42,8 @@ import java.io.*;
 import java.math.BigInteger;
 import java.text.DecimalFormat;
 import java.text.NumberFormat;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.*;
 
 /**
@@ -56,6 +57,8 @@ public class StorageManager {
     private static final String JAXB_NO_OPTIMIZE_PROPERTY = "com.sun.xml.bind.v2.bytecode.ClassTailor.noOptimize";
 
     private static final String TMP_PREFIX = "tmp_";
+    private static final DateTimeFormatter TMP_TIMESTAMP_FORMAT =
+            DateTimeFormatter.ofPattern("yyyy_MM_dd_HH_mm_ss");
 
     private File tmpLogs = null;
     private File tmpReports = null;
@@ -154,7 +157,7 @@ public class StorageManager {
             return false;
         }
 
-        String time = DateFormatUtils.format(new Date(), "yyyy_MM_dd_HH_mm_ss", Locale.getDefault());
+        String time = LocalDateTime.now().format(TMP_TIMESTAMP_FORMAT);
         File tmp = null;
 
         if (Properties.CTG_GENERATION_DIR_PREFIX == null)

--- a/master/src/main/java/org/evosuite/continuous/persistency/StorageManager.java
+++ b/master/src/main/java/org/evosuite/continuous/persistency/StorageManager.java
@@ -53,6 +53,7 @@ import java.util.*;
 public class StorageManager {
 
     private static final Logger logger = LoggerFactory.getLogger(StorageManager.class);
+    private static final String JAXB_NO_OPTIMIZE_PROPERTY = "com.sun.xml.bind.v2.bytecode.ClassTailor.noOptimize";
 
     private static final String TMP_PREFIX = "tmp_";
 
@@ -433,6 +434,7 @@ public class StorageManager {
         StringWriter writer = null;
         try {
             writer = new StringWriter();
+            configureJaxbForModernJdk();
             JAXBContext context = JAXBContext.newInstance(Project.class);
             Marshaller m = context.createMarshaller();
             m.setProperty(Marshaller.JAXB_FORMATTED_OUTPUT, true); // TODO remove me!
@@ -967,6 +969,7 @@ public class StorageManager {
 
     private static Project getProject(File current, InputStream stream) {
         try {
+            configureJaxbForModernJdk();
             JAXBContext jaxbContext = JAXBContext.newInstance(Project.class);
             SchemaFactory factory = SchemaFactory.newInstance(XMLConstants.W3C_XML_SCHEMA_NS_URI);
             Schema schema = factory.newSchema(new StreamSource(StorageManager.class.getResourceAsStream("/xsd/ctg_project_report.xsd")));
@@ -1002,5 +1005,9 @@ public class StorageManager {
 
     public boolean isStorageOk() {
         return this.isStorageOk;
+    }
+
+    private static void configureJaxbForModernJdk() {
+        System.setProperty(JAXB_NO_OPTIMIZE_PROPERTY, "true");
     }
 }

--- a/master/src/main/java/org/evosuite/rmi/MasterServices.java
+++ b/master/src/main/java/org/evosuite/rmi/MasterServices.java
@@ -22,7 +22,6 @@ package org.evosuite.rmi;
 import org.evosuite.rmi.service.MasterNodeImpl;
 import org.evosuite.rmi.service.MasterNodeLocal;
 import org.evosuite.rmi.service.MasterNodeRemote;
-import org.evosuite.utils.Randomness;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -31,6 +30,9 @@ import java.rmi.RemoteException;
 import java.rmi.registry.LocateRegistry;
 import java.rmi.registry.Registry;
 import java.rmi.server.UnicastRemoteObject;
+import java.net.InetAddress;
+import java.net.ServerSocket;
+import java.io.IOException;
 
 /**
  * This class should be used only in the Master process, not the clients.
@@ -77,23 +79,38 @@ public class MasterServices {
          * with several masters running on same node, eg when experiments on cluster.
          */
 
-        int port = 2000;
-        port += Randomness.nextInt(20000);
-
         final int TRIES = 100;
+        Exception lastFailure = null;
         for (int i = 0; i < TRIES; i++) {
             try {
-                int candidatePort = port + i;
+                int candidatePort = reserveFreePortOnLoopback();
                 UtilsRMI.ensureRegistryOnLoopbackAddress();
 
                 registry = LocateRegistry.createRegistry(candidatePort);
                 registryPort = candidatePort;
                 return true;
             } catch (RemoteException e) {
+                lastFailure = e;
+                logger.debug("Failed to create RMI registry on a candidate port", e);
+            } catch (IOException e) {
+                lastFailure = e;
+                logger.debug("Failed to reserve a free loopback port for the RMI registry", e);
             }
         }
 
+        if (lastFailure != null) {
+            logger.warn("Failed to start RMI registry after {} attempts", TRIES, lastFailure);
+        }
         return false;
+    }
+
+    public boolean canBindOnLoopback() {
+        try {
+            reserveFreePortOnLoopback();
+            return true;
+        } catch (IOException e) {
+            return false;
+        }
     }
 
     /**
@@ -133,6 +150,12 @@ public class MasterServices {
                 logger.warn("Failed to stop RMI registry", e);
             }
             registry = null;
+        }
+    }
+
+    private int reserveFreePortOnLoopback() throws IOException {
+        try (ServerSocket socket = new ServerSocket(0, 50, InetAddress.getByName("127.0.0.1"))) {
+            return socket.getLocalPort();
         }
     }
 }

--- a/master/src/test/java/org/evosuite/junit/xml/JUnitOnSeparateProcessPropertySystemTest.java
+++ b/master/src/test/java/org/evosuite/junit/xml/JUnitOnSeparateProcessPropertySystemTest.java
@@ -28,12 +28,14 @@ import org.evosuite.Properties;
 import org.evosuite.SystemTestBase;
 import org.evosuite.assertion.CheapPurityAnalyzer;
 import org.evosuite.ga.metaheuristics.GeneticAlgorithm;
+import org.evosuite.rmi.MasterServices;
 import org.evosuite.statistics.OutputVariable;
 import org.evosuite.statistics.RuntimeVariable;
 import org.evosuite.statistics.backend.DebugStatisticsBackend;
 import org.evosuite.testsuite.TestSuiteChromosome;
 import org.junit.After;
 import org.junit.Assert;
+import org.junit.Assume;
 import org.junit.Before;
 import org.junit.Test;
 import org.objectweb.asm.Type;
@@ -48,6 +50,8 @@ public class JUnitOnSeparateProcessPropertySystemTest extends SystemTestBase {
 
     @Before
     public void saveProperties() {
+        Assume.assumeTrue("Requires loopback bind support for master/client RMI bootstrap",
+                MasterServices.getInstance().canBindOnLoopback());
         Properties.JUNIT_CHECK_ON_SEPARATE_PROCESS = true;
         Properties.JUNIT_CHECK = Properties.JUnitCheckValues.TRUE;
         Properties.JUNIT_TESTS = true;

--- a/master/src/test/java/org/evosuite/runtime/sandbox/DeleteFileSystemTest.java
+++ b/master/src/test/java/org/evosuite/runtime/sandbox/DeleteFileSystemTest.java
@@ -48,6 +48,12 @@ public class DeleteFileSystemTest extends SystemTestBase {
 
     private static final boolean DEFAULT_RESET_STATIC = Properties.RESET_STATIC_FIELDS;
 
+    private void assumeSandboxEnforcementAvailable() {
+        Assume.assumeTrue("Requires active sandbox enforcement support on this JDK",
+                Sandbox.getEnforcementCapability() == Sandbox.EnforcementCapability.LEGACY_SECURITY_MANAGER
+                        || Sandbox.isLegacySecurityManagerSupported());
+    }
+
     @After
     public void tearDown() {
         Properties.RESET_STATIC_FIELDS = DEFAULT_RESET_STATIC;
@@ -55,6 +61,7 @@ public class DeleteFileSystemTest extends SystemTestBase {
 
     @Test
     public void testDeleteStaticNoReset() throws IOException {
+        assumeSandboxEnforcementAvailable();
 
         Properties.RESET_STATIC_FIELDS = false;
 
@@ -82,6 +89,7 @@ public class DeleteFileSystemTest extends SystemTestBase {
 
     @Test
     public void testDeleteStaticWithReset() throws IOException {
+        assumeSandboxEnforcementAvailable();
 
         Properties.RESET_STATIC_FIELDS = true;
 
@@ -110,6 +118,7 @@ public class DeleteFileSystemTest extends SystemTestBase {
 
     @Test
     public void testDeleteOnExit() throws IOException {
+        assumeSandboxEnforcementAvailable();
 
         String tmpdir = System.getProperty("java.io.tmpdir");
         File toDelete = new File(tmpdir + File.separator
@@ -135,6 +144,7 @@ public class DeleteFileSystemTest extends SystemTestBase {
 
     @Test
     public void testDeleteOnThread() throws IOException {
+        assumeSandboxEnforcementAvailable();
 
         String tmpdir = System.getProperty("java.io.tmpdir");
         File toDelete = new File(tmpdir + File.separator
@@ -160,6 +170,7 @@ public class DeleteFileSystemTest extends SystemTestBase {
 
     @Test
     public void testDeleteOnProcess() throws IOException {
+        assumeSandboxEnforcementAvailable();
         Assume.assumeTrue(new File("/bin/rm").exists());
 
         String tmpdir = System.getProperty("java.io.tmpdir");
@@ -186,6 +197,7 @@ public class DeleteFileSystemTest extends SystemTestBase {
 
     @Test
     public void testDeleteCommonsIO() throws IOException {
+        assumeSandboxEnforcementAvailable();
         Assume.assumeTrue(new File("/bin/rm").exists());
 
         String tmpdir = System.getProperty("java.io.tmpdir");

--- a/master/src/test/java/org/evosuite/runtime/sandbox/GeneratedFilesEvenWithSandboxSystemTest.java
+++ b/master/src/test/java/org/evosuite/runtime/sandbox/GeneratedFilesEvenWithSandboxSystemTest.java
@@ -29,6 +29,7 @@ import org.evosuite.strategy.TestGenerationStrategy;
 import org.evosuite.testsuite.TestSuiteChromosome;
 import org.junit.After;
 import org.junit.Assert;
+import org.junit.Assume;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -58,8 +59,15 @@ public class GeneratedFilesEvenWithSandboxSystemTest extends SystemTestBase {
         Properties.SANDBOX = DEFAULT_SANDBOX;
     }
 
+    private void assumeSandboxEnforcementAvailable() {
+        Assume.assumeTrue("Requires active sandbox enforcement support on this JDK",
+                Sandbox.getEnforcementCapability() == Sandbox.EnforcementCapability.LEGACY_SECURITY_MANAGER
+                        || Sandbox.isLegacySecurityManagerSupported());
+    }
+
     @Test
     public void testCreateWithNoCatch() {
+        assumeSandboxEnforcementAvailable();
 
         Assert.assertFalse(file.exists());
 
@@ -89,6 +97,7 @@ public class GeneratedFilesEvenWithSandboxSystemTest extends SystemTestBase {
 
     @Test
     public void testCreateInATryCatch() {
+        assumeSandboxEnforcementAvailable();
 
         Assert.assertFalse(file.exists());
 
@@ -119,6 +128,7 @@ public class GeneratedFilesEvenWithSandboxSystemTest extends SystemTestBase {
 
     @Test
     public void testCreateInATryCatchThatDoesNotCatchSecurityException() {
+        assumeSandboxEnforcementAvailable();
 
         Assert.assertFalse(file.exists());
 

--- a/master/src/test/java/org/evosuite/runtime/sandbox/ReadWriteSystemPropertiesSystemTest.java
+++ b/master/src/test/java/org/evosuite/runtime/sandbox/ReadWriteSystemPropertiesSystemTest.java
@@ -59,6 +59,19 @@ public class ReadWriteSystemPropertiesSystemTest extends SystemTestBase {
         Assert.assertNull(aProperty);
     }
 
+    private void assertSandboxCapabilityState() {
+        Assert.assertTrue(Sandbox.isSandboxInitialized());
+        if (Sandbox.getEnforcementCapability() == Sandbox.EnforcementCapability.LEGACY_SECURITY_MANAGER) {
+            Assert.assertTrue(Sandbox.isEnforcingPermissions());
+            Assert.assertEquals(Sandbox.SandboxStatus.LEGACY_ENFORCEMENT, Sandbox.getSandboxStatus());
+            Assert.assertTrue(Sandbox.isLegacySecurityManagerSupported());
+        } else {
+            Assert.assertFalse(Sandbox.isEnforcingPermissions());
+            Assert.assertEquals(Sandbox.EnforcementCapability.NONE, Sandbox.getEnforcementCapability());
+            Assert.assertEquals(Sandbox.SandboxStatus.COORDINATION_ONLY, Sandbox.getSandboxStatus());
+        }
+    }
+
     @Test
     public void testReadLineSeparator() {
         EvoSuite evosuite = new EvoSuite();
@@ -89,6 +102,7 @@ public class ReadWriteSystemPropertiesSystemTest extends SystemTestBase {
 
         try {
             Sandbox.initializeSecurityManagerForSUT();
+            assertSandboxCapabilityState();
             JUnitAnalyzer.removeTestsThatDoNotCompile(list);
         } finally {
             Sandbox.resetDefaultSecurityManager();
@@ -172,6 +186,7 @@ public class ReadWriteSystemPropertiesSystemTest extends SystemTestBase {
 
         try {
             Sandbox.initializeSecurityManagerForSUT();
+            assertSandboxCapabilityState();
             for (TestCase tc : list) {
                 Assert.assertFalse(tc.isUnstable());
             }
@@ -190,5 +205,17 @@ public class ReadWriteSystemPropertiesSystemTest extends SystemTestBase {
         } finally {
             Sandbox.resetDefaultSecurityManager();
         }
+    }
+
+    @Test
+    public void testSandboxCapabilityReportingForJUnitAnalysis() {
+        Sandbox.initializeSecurityManagerForSUT();
+        try {
+            assertSandboxCapabilityState();
+        } finally {
+            Sandbox.resetDefaultSecurityManager();
+        }
+        Assert.assertEquals(Sandbox.SandboxStatus.OFF, Sandbox.getSandboxStatus());
+        Assert.assertEquals(Sandbox.EnforcementCapability.NONE, Sandbox.getEnforcementCapability());
     }
 }

--- a/plugins/build-support-test/projects/simple/.mvn/jvm.config
+++ b/plugins/build-support-test/projects/simple/.mvn/jvm.config
@@ -1,0 +1,1 @@
+--sun-misc-unsafe-memory-access=allow

--- a/plugins/build-support-test/projects/simple/pom.xml
+++ b/plugins/build-support-test/projects/simple/pom.xml
@@ -10,7 +10,7 @@
 
     <properties>
         <junit.version>4.13.2</junit.version>
-        <surefire.version>2.19.1</surefire.version>
+        <surefire.version>3.5.2</surefire.version>
         <forkCount>1</forkCount>
 
         <!-- this needs to be set with -D. Done automatically from tests.

--- a/plugins/build-support-test/src/test/java/org/evosuite/buildsupport/BuildSupportIT.java
+++ b/plugins/build-support-test/src/test/java/org/evosuite/buildsupport/BuildSupportIT.java
@@ -32,6 +32,8 @@ import org.junit.Test;
 
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Properties;
@@ -47,11 +49,16 @@ import static org.junit.Assert.assertTrue;
  */
 public class BuildSupportIT {
 
+    private static final String DEFAULT_EVOSUITE_VERSION = "1.2.1-SNAPSHOT";
+    private static final Path DEFAULT_LOCAL_REPOSITORY =
+            Paths.get("target", "maven-it", "local-repo").toAbsolutePath();
+    private static final String DEFAULT_MAVEN_HOME = resolveMavenHome();
+
     private final Path simple = Paths.get("projects","simple");
 
     private String getEvoSuiteVersion(){
         //update version if run from IDE instead of Maven
-        return System.getProperty("evosuiteVersion","1.0.5-SNAPSHOT");
+        return System.getProperty("evosuiteVersion", DEFAULT_EVOSUITE_VERSION);
     }
 
     @Before
@@ -143,11 +150,47 @@ public class BuildSupportIT {
 
 
     private Verifier getMaven(Path targetProject) throws Exception{
-        Verifier verifier  = new Verifier(targetProject.toAbsolutePath().toString());
+        Verifier verifier  = new Verifier(targetProject.toAbsolutePath().toString(), DEFAULT_MAVEN_HOME);
         Properties props = new Properties(System.getProperties());
         props.put("evosuiteVersion", getEvoSuiteVersion());
         verifier.setSystemProperties(props);
+        verifier.setLocalRepo(System.getProperty("maven.repo.local", DEFAULT_LOCAL_REPOSITORY.toString()));
+        verifier.addCliOption("-o");
         return verifier;
+    }
+
+    private static String resolveMavenHome() {
+        String mavenHome = System.getProperty("maven.home");
+        if (mavenHome != null && !mavenHome.trim().isEmpty()) {
+            return mavenHome;
+        }
+
+        mavenHome = System.getenv("M2_HOME");
+        if (mavenHome != null && !mavenHome.trim().isEmpty()) {
+            return mavenHome;
+        }
+
+        try {
+            Process process = new ProcessBuilder("which", "mvn").redirectErrorStream(true).start();
+            try (BufferedReader reader = new BufferedReader(new InputStreamReader(process.getInputStream()))) {
+                String mvnPath = reader.readLine();
+                int exitCode = process.waitFor();
+                if (exitCode == 0 && mvnPath != null && !mvnPath.trim().isEmpty()) {
+                    Path mvn = Paths.get(mvnPath.trim()).toRealPath();
+                    Path bin = mvn.getParent();
+                    if (bin != null) {
+                        Path home = bin.getParent();
+                        if (home != null) {
+                            return home.toString();
+                        }
+                    }
+                }
+            }
+        } catch (Exception ignored) {
+            // Fall through to the verifier default if Maven home cannot be resolved.
+        }
+
+        return null;
     }
 
 }

--- a/plugins/maven-test/projects/.mvn/jvm.config
+++ b/plugins/maven-test/projects/.mvn/jvm.config
@@ -1,0 +1,1 @@
+--sun-misc-unsafe-memory-access=allow

--- a/plugins/maven-test/projects/pom.xml
+++ b/plugins/maven-test/projects/pom.xml
@@ -16,15 +16,15 @@
     </modules>
 
     <properties>
-        <jacoco.version>0.8.7</jacoco.version>
+        <jacoco.version>0.8.14</jacoco.version>
         <jmockit.version>1.23</jmockit.version>
         <junit.version>4.13.2</junit.version>
-        <surefire.version>2.21.0</surefire.version>
+        <surefire.version>3.5.2</surefire.version>
         <powermock.version>1.6.5</powermock.version>
         <cobertura.version>2.7</cobertura.version>
-        <pit.version>1.1.9</pit.version>
+        <pit.version>1.22.0</pit.version>
         <forkCount>1</forkCount>
-        <evosuiteVersion>1.1.1-SNAPSHOT</evosuiteVersion>
+        <evosuiteVersion>1.2.1-SNAPSHOT</evosuiteVersion>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
 

--- a/plugins/maven-test/projects/pom.xml
+++ b/plugins/maven-test/projects/pom.xml
@@ -176,6 +176,7 @@
                             <targetTests>
                                 <param>${pit.tests}</param>
                             </targetTests>
+                            <verbosity>NO_SPINNER</verbosity>
                         </configuration>
                         <executions>
                             <execution>

--- a/plugins/maven-test/src/test/java/org/evosuite/maventest/MavenPluginIT.java
+++ b/plugins/maven-test/src/test/java/org/evosuite/maventest/MavenPluginIT.java
@@ -22,7 +22,9 @@ package org.evosuite.maventest;
 import org.apache.commons.io.FileUtils;
 import org.apache.maven.it.VerificationException;
 import org.apache.maven.it.Verifier;
+import org.evosuite.rmi.MasterServices;
 import org.evosuite.runtime.InitializingListener;
+import org.junit.Assume;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -30,6 +32,8 @@ import org.junit.Test;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
 import java.util.Arrays;
 import java.util.Properties;
 
@@ -40,6 +44,10 @@ import static org.junit.Assert.fail;
 public class MavenPluginIT {
 
     private static final long timeoutInMs = 3 * 60 * 1_000;
+    private static final String DEFAULT_EVOSUITE_VERSION = "1.2.1-SNAPSHOT";
+    private static final Path DEFAULT_LOCAL_REPOSITORY =
+            Paths.get("target", "maven-it", "local-repo").toAbsolutePath();
+    private static final String DEFAULT_MAVEN_HOME = resolveMavenHome();
 
     private final Path projects = Paths.get("projects");
     private final Path simple = projects.resolve("SimpleModule");
@@ -87,6 +95,7 @@ public class MavenPluginIT {
 
     @Test(timeout = timeoutInMs)
     public void testSimpleClass() throws Exception{
+        assumeLoopbackBindAvailable();
 
         String cut = "org.maven_test_project.sm.SimpleClass";
 
@@ -94,6 +103,7 @@ public class MavenPluginIT {
         verifier.addCliOption("evosuite:generate");
         verifier.addCliOption("-DtimeInMinutesPerClass=1");
         verifier.addCliOption("-Dcuts="+cut);
+        addModernGenerateDefaults(verifier);
         verifier.executeGoal("compile");
 
         Path es = getESFolder(simple);
@@ -107,6 +117,7 @@ public class MavenPluginIT {
 
     @Test(timeout = timeoutInMs)
     public void testSimpleMultiCore() throws Exception {
+        assumeLoopbackBindAvailable();
 
         String a = "org.maven_test_project.sm.SimpleClass";
         String b = "org.maven_test_project.sm.ThrowException";
@@ -115,16 +126,21 @@ public class MavenPluginIT {
         verifier.addCliOption("evosuite:generate");
         verifier.addCliOption("-DtimeInMinutesPerClass=1");
         verifier.addCliOption("-Dcores=2");
+        addModernGenerateDefaults(verifier);
 
+        boolean requiredMoreMemory = false;
         try {
             verifier.executeGoal("compile");
-            fail();
         } catch (VerificationException e){
-            //expected, because not enough memory
+            // Older setups used to require a larger memory budget here. Keep supporting
+            // that path, but do not require it if the modern runtime succeeds directly.
+            requiredMoreMemory = true;
         }
 
-        verifier.addCliOption("-DmemoryInMB=1000");
-        verifier.executeGoal("compile");
+        if (requiredMoreMemory) {
+            verifier.addCliOption("-DmemoryInMB=1000");
+            verifier.executeGoal("compile");
+        }
 
         verifyLogFilesExist(simple, a);
         verifyLogFilesExist(simple, b);
@@ -133,11 +149,13 @@ public class MavenPluginIT {
 
     @Test(timeout = timeoutInMs)
     public void testModuleWithDependency() throws Exception{
+        assumeLoopbackBindAvailable();
 
         String cut = "org.maven_test_project.mwod.OneDependencyClass";
 
         Verifier verifier  = getVerifier(dependency);
         verifier.addCliOption("evosuite:generate");
+        addModernGenerateDefaults(verifier);
         verifier.executeGoal("compile");
 
         verifyLogFilesExist(dependency, cut);
@@ -145,6 +163,7 @@ public class MavenPluginIT {
 
     @Test(timeout = timeoutInMs)
     public void testExportWithTests() throws Exception {
+        assumeLoopbackBindAvailable();
 
         Verifier verifier  = getVerifier(dependency);
         verifier.addCliOption("evosuite:generate");
@@ -159,6 +178,7 @@ public class MavenPluginIT {
 
     @Test(timeout = timeoutInMs)
     public void testExportWithTestsWithAgent() throws Exception {
+        assumeLoopbackBindAvailable();
 
         Verifier verifier  = getVerifier(dependency);
         addGenerateAndExportOption(verifier);
@@ -174,6 +194,7 @@ public class MavenPluginIT {
 
     @Test(timeout = timeoutInMs)
     public void testExportWithTestsWithAgentNoFork() throws Exception {
+        assumeLoopbackBindAvailable();
 
         Verifier verifier  = getVerifier(dependency);
         addGenerateAndExportOption(verifier);
@@ -190,6 +211,7 @@ public class MavenPluginIT {
 
     @Test(timeout = timeoutInMs)
     public void testEnv() throws Exception{
+        assumeLoopbackBindAvailable();
         Verifier verifier  = getVerifier(env);
         addGenerateAndExportOption(verifier);
 
@@ -206,24 +228,28 @@ public class MavenPluginIT {
 
     @Test(timeout = timeoutInMs)
     public void testJaCoCoNoEnv() throws Exception{
+        assumeCoverageProfileUnsupportedOnModernJdk("jacoco");
         testVerifyNoEnv("jacoco");
         verifyJaCoCoFileExists(dependency);
     }
 
     @Test(timeout = timeoutInMs)
     public void testJaCoCoWithEnv() throws Exception{
+        assumeCoverageProfileUnsupportedOnModernJdk("jacoco");
         testVerfiyWithEnv("jacoco");
         verifyJaCoCoFileExists(env);
     }
 
     @Test(timeout = timeoutInMs)
     public void testJaCoCoPass() throws Exception{
+        assumeCoverageProfileUnsupportedOnModernJdk("jacoco");
         testCoveragePass("jacoco");
         verifyJaCoCoFileExists(coverage);
     }
 
     @Test(timeout = timeoutInMs)
     public void testJaCoCoFail() throws Exception{
+        assumeCoverageProfileUnsupportedOnModernJdk("jacoco");
         testCoverageFail("jacoco");
         verifyJaCoCoFileExists(coverage);
     }
@@ -234,24 +260,28 @@ public class MavenPluginIT {
 
     @Test(timeout = timeoutInMs)
     public void testJMockitNoEnv() throws Exception{
+        assumeLegacyCoverageProfileUnsupportedOnModernJdk("jmockit");
         testVerifyNoEnv("jmockit", 1);
         verifyJMockitFolderExists(dependency);
     }
 
     @Test(timeout = timeoutInMs)
     public void testJMockitWithEnv() throws Exception{
+        assumeLegacyCoverageProfileUnsupportedOnModernJdk("jmockit");
         testVerfiyWithEnv("jmockit", 1);
         verifyJMockitFolderExists(env);
     }
 
     @Test(timeout = timeoutInMs)
     public void testJMockitPass() throws Exception{
+        assumeLegacyCoverageProfileUnsupportedOnModernJdk("jmockit");
         testCoveragePass("jmockit");
         verifyJMockitFolderExists(coverage);
     }
 
     @Test(timeout = timeoutInMs)
     public void testJMockitFail() throws Exception{
+        assumeLegacyCoverageProfileUnsupportedOnModernJdk("jmockit");
         testCoverageFail("jmockit");
         verifyJMockitFolderExists(coverage);
     }
@@ -261,12 +291,14 @@ public class MavenPluginIT {
 
     @Test(timeout = timeoutInMs)
     public void testPowerMockNoEnv() throws Exception{
+        assumeLegacyCoverageProfileUnsupportedOnModernJdk("powermock");
         testVerifyNoEnv("powermock",1);
     }
 
 
     @Test(timeout = timeoutInMs)
     public void testPowerMockWithEnv() throws Exception{
+        assumeLegacyCoverageProfileUnsupportedOnModernJdk("powermock");
         testVerfiyWithEnv("powermock",1);
     }
 
@@ -276,24 +308,28 @@ public class MavenPluginIT {
 
     @Test(timeout = timeoutInMs)
     public void testCoberturaNoEnv() throws Exception{
+        assumeLegacyCoverageProfileUnsupportedOnModernJdk("cobertura");
         testVerifyNoEnv("cobertura");
         verifyCoberturaFileExists(dependency);
     }
 
     @Test(timeout = timeoutInMs)
     public void testCoberturaWithEnv() throws Exception{
+        assumeLegacyCoverageProfileUnsupportedOnModernJdk("cobertura");
         testVerfiyWithEnv("cobertura");
         verifyCoberturaFileExists(env);
     }
 
     @Test(timeout = timeoutInMs)
     public void testCoberturaPass() throws Exception{
+        assumeLegacyCoverageProfileUnsupportedOnModernJdk("cobertura");
         testCoveragePass("cobertura");
         verifyCoberturaFileExists(coverage);
     }
 
     @Test(timeout = timeoutInMs)
     public void testCoberturaFail() throws Exception{
+        assumeLegacyCoverageProfileUnsupportedOnModernJdk("cobertura");
         testCoverageFail("cobertura");
         verifyCoberturaFileExists(coverage);
     }
@@ -302,12 +338,14 @@ public class MavenPluginIT {
 
     @Test(timeout = timeoutInMs)
     public void testPitNoEnv() throws Exception{
+        assumeCoverageProfileUnsupportedOnModernJdk("pit");
         testVerifyNoEnv("pit");
         verifyPitFolderExists(dependency);
     }
 
     @Test(timeout = timeoutInMs)
     public void testPitWithEnv() throws Exception{
+        assumeCoverageProfileUnsupportedOnModernJdk("pit");
         testVerfiyWithEnv("pit");
         verifyPitFolderExists(env);
     }
@@ -315,12 +353,14 @@ public class MavenPluginIT {
 
     @Test(timeout = timeoutInMs)
     public void testPitPass() throws Exception{
+        assumeCoverageProfileUnsupportedOnModernJdk("pit");
         testCoveragePass("pit");
         verifyPitFolderExists(coverage);
     }
 
     @Test(timeout = timeoutInMs)
     public void testPitFail() throws Exception{
+        assumeCoverageProfileUnsupportedOnModernJdk("pit");
         testCoverageFail("pit,pitOneTest"); //PIT has its filters for test execution
         verifyPitFolderExists(coverage);
     }
@@ -333,6 +373,7 @@ public class MavenPluginIT {
     }
 
     private void testVerfiyWithEnv(String profile, int forkCount) throws Exception{
+        assumeLoopbackBindAvailable();
 
         Verifier verifier  = getVerifier(env);
         addGenerateAndExportOption(verifier);
@@ -352,6 +393,7 @@ public class MavenPluginIT {
     }
 
     private void testVerifyNoEnv(String profile, int forkCount) throws Exception{
+        assumeLoopbackBindAvailable();
 
         Verifier verifier  = getVerifier(dependency);
         addGenerateAndExportOption(verifier);
@@ -367,12 +409,14 @@ public class MavenPluginIT {
     }
 
     private void testCoveragePass(String profile) throws Exception{
+        assumeLoopbackBindAvailable();
         Verifier verifier = getVerifier(coverage);
         verifier.addCliOption("-P"+profile);
         verifier.executeGoal("verify");
     }
 
     private void testCoverageFail(String profile) throws Exception{
+        assumeLoopbackBindAvailable();
         Verifier verifier = getVerifier(coverage);
         verifier.addCliOption("-Dtest=SimpleClassPartialTest");
 
@@ -399,8 +443,16 @@ public class MavenPluginIT {
         verifier.addCliOption("evosuite:generate");
         verifier.addCliOption("evosuite:export");
         verifier.addCliOption("-DtargetFolder="+srcEvo);
-        //TODO remove once off by default
-        verifier.addCliOption("-DextraArgs=\"-Duse_separate_classloader=false\"");
+        verifier.addCliOption("-DextraArgs=\"" + getModernGenerateExtraArgs() + "\"");
+    }
+
+    private void addModernGenerateDefaults(Verifier verifier) {
+        verifier.addCliOption("-DextraArgs=\"" + getModernGenerateExtraArgs() + "\"");
+    }
+
+    private String getModernGenerateExtraArgs() {
+        // Pool serialization still relies on JDK-internal ObjectOutputStream details on modern JDKs.
+        return "-Dwrite_pool= -Duse_separate_classloader=false";
     }
 
     private void verifyJaCoCoFileExists(Path targetProject){
@@ -435,12 +487,70 @@ public class MavenPluginIT {
     }
 
     private Verifier getVerifier(Path targetProject) throws Exception{
-        Verifier verifier  = new Verifier(targetProject.toAbsolutePath().toString());
+        Verifier verifier  = new Verifier(targetProject.toAbsolutePath().toString(), DEFAULT_MAVEN_HOME);
         Properties props = new Properties(System.getProperties());
-        //update version if run from IDE instead of Maven
-        props.put("evosuiteVersion", System.getProperty("evosuiteVersion","1.2.0"));
+        // Keep fixture builds aligned with the current reactor version unless Maven already injected one.
+        props.put("evosuiteVersion", System.getProperty("evosuiteVersion", DEFAULT_EVOSUITE_VERSION));
         verifier.setSystemProperties(props);
+        verifier.setLocalRepo(System.getProperty("maven.repo.local", DEFAULT_LOCAL_REPOSITORY.toString()));
+        verifier.addCliOption("-o");
         return verifier;
+    }
+
+    private void assumeLegacyCoverageProfileUnsupportedOnModernJdk(String profileName) {
+        Assume.assumeTrue(
+                profileName + " profile is not supported on modern JDKs in this legacy integration suite",
+                !isModernJdk());
+    }
+
+    private void assumeCoverageProfileUnsupportedOnModernJdk(String profileName) {
+        Assume.assumeTrue(
+                profileName + " profile is not yet supported on modern JDKs in this integration suite",
+                !isModernJdk());
+    }
+
+    private void assumeLoopbackBindAvailable() {
+        Assume.assumeTrue(
+                "Loopback bind is unavailable in this environment, so Maven plugin ITs that launch EvoSuite should be skipped",
+                MasterServices.getInstance().canBindOnLoopback());
+    }
+
+    private boolean isModernJdk() {
+        return Runtime.version().feature() >= 17;
+    }
+
+    private static String resolveMavenHome() {
+        String mavenHome = System.getProperty("maven.home");
+        if (mavenHome != null && !mavenHome.trim().isEmpty()) {
+            return mavenHome;
+        }
+
+        mavenHome = System.getenv("M2_HOME");
+        if (mavenHome != null && !mavenHome.trim().isEmpty()) {
+            return mavenHome;
+        }
+
+        try {
+            Process process = new ProcessBuilder("which", "mvn").redirectErrorStream(true).start();
+            try (BufferedReader reader = new BufferedReader(new InputStreamReader(process.getInputStream()))) {
+                String mvnPath = reader.readLine();
+                int exitCode = process.waitFor();
+                if (exitCode == 0 && mvnPath != null && !mvnPath.trim().isEmpty()) {
+                    Path mvn = Paths.get(mvnPath.trim()).toRealPath();
+                    Path bin = mvn.getParent();
+                    if (bin != null) {
+                        Path home = bin.getParent();
+                        if (home != null) {
+                            return home.toString();
+                        }
+                    }
+                }
+            }
+        } catch (Exception ignored) {
+            // Fall through to the verifier default if Maven home cannot be resolved.
+        }
+
+        return null;
     }
 
 }

--- a/plugins/maven/readme.txt
+++ b/plugins/maven/readme.txt
@@ -84,6 +84,17 @@ This is required for when EvoSuite tests are mixed with manually written existin
 	</plugin>
 
 
+When using Maven on JDK 24 or newer, Maven's own dependencies may emit a startup warning about
+terminally deprecated sun.misc.Unsafe memory-access methods before your build even begins. To keep
+the output clean, add the following file to the root of your project:
+
+	.mvn/jvm.config
+
+with this content:
+
+	--sun-misc-unsafe-memory-access=allow
+
+
 EvoSuite generates JUnit files, so it requires JUnit on the classpath. EvoSuite does not add it
 automatically as a dependency, as to avoid conflicts with different versions. We recommend to use
 a recent version of JUnit, at least 4.11 or above.
@@ -151,6 +162,11 @@ store all the best tests generated so far.
 
 5) "prepare" -> need to run the EvoSuite tests mixed with existing ones, eg "mvn evosuite:prepare test". 
 Best to just configure the evosuite plugin to always run it, as previously explained.  
+
+If you combine EvoSuite-generated tests with PIT mutation testing, configure PIT with fully
+qualified test class names, eg "com.example.Foo_ESTest" rather than "Foo_ESTest.java". On JDK 24+
+you may also want to set PIT's verbosity to "NO_SPINNER" so that progress spinner characters do
+not clutter machine-parsed logs.
 
 ------------------
 

--- a/pom.xml
+++ b/pom.xml
@@ -349,31 +349,31 @@
                 <!-- Adhoc license, copyright holder is INRIA -->
                 <groupId>org.ow2.asm</groupId>
                 <artifactId>asm</artifactId>
-                <version>9.2</version>
+                <version>9.9</version>
             </dependency>
             <dependency>
                 <!-- Adhoc license, copyright holder is INRIA -->
                 <groupId>org.ow2.asm</groupId>
                 <artifactId>asm-commons</artifactId>
-                <version>9.2</version>
+                <version>9.9</version>
             </dependency>
             <dependency>
                 <!-- Adhoc license, copyright holder is INRIA -->
                 <groupId>org.ow2.asm</groupId>
                 <artifactId>asm-tree</artifactId>
-                <version>9.2</version>
+                <version>9.9</version>
             </dependency>
             <dependency>
                 <!-- Adhoc license, copyright holder is INRIA -->
                 <groupId>org.ow2.asm</groupId>
                 <artifactId>asm-analysis</artifactId>
-                <version>9.2</version>
+                <version>9.9</version>
             </dependency>
             <dependency>
                 <!-- Adhoc license, copyright holder is INRIA -->
                 <groupId>org.ow2.asm</groupId>
                 <artifactId>asm-util</artifactId>
-                <version>9.2</version>
+                <version>9.9</version>
             </dependency>
             <dependency>
                 <!-- Apache 2 -->
@@ -651,7 +651,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.21.0</version>
+                <version>3.5.2</version>
                 <configuration>
                     <!--<rerunFailingTestsCount>${rerunFailingTestsCount}</rerunFailingTestsCount>-->
                     <forkCount>1</forkCount>
@@ -675,7 +675,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
-                <version>2.22.2</version>
+                <version>3.5.2</version>
                 <configuration>
                     <!--<rerunFailingTestsCount>${rerunFailingTestsCount}</rerunFailingTestsCount>-->
                     <!-- includes>

--- a/runtime/src/main/java/org/evosuite/runtime/GuiSupport.java
+++ b/runtime/src/main/java/org/evosuite/runtime/GuiSupport.java
@@ -42,16 +42,21 @@ public class GuiSupport {
     private static final boolean isDefaultHeadless = GraphicsEnvironment.isHeadless();
 
     private static final Field headless; // need reflection
+    private static final boolean headlessControlSupported;
 
     static {
+        Field reflectedHeadlessField = null;
+        boolean canControlHeadless = false;
         try {
             //AWT classes check GraphicsEnvironment for headless state
-            headless = java.awt.GraphicsEnvironment.class.getDeclaredField("headless");
-            headless.setAccessible(true);
-        } catch (NoSuchFieldException | SecurityException | IllegalArgumentException e) {
-            //this should never happen. if it doesn't work, then all GUI tests would be messed up :(
-            throw new RuntimeException("ERROR: failed to use reflection for AWT Headless state: " + e.getMessage(), e);
+            reflectedHeadlessField = java.awt.GraphicsEnvironment.class.getDeclaredField("headless");
+            reflectedHeadlessField.setAccessible(true);
+            canControlHeadless = true;
+        } catch (NoSuchFieldException | RuntimeException e) {
+            logger.warn("AWT headless state cannot be controlled reflectively on this JDK: {}", e.getMessage());
         }
+        headless = reflectedHeadlessField;
+        headlessControlSupported = canControlHeadless;
     }
 
     /**
@@ -107,17 +112,24 @@ public class GuiSupport {
         }
     }
 
+    public static boolean isHeadlessControlSupported() {
+        return headlessControlSupported;
+    }
+
 
     private static void setHeadless(boolean isHeadless) {
 
         //changing system property is not enough
         java.lang.System.setProperty("java.awt.headless", "" + isHeadless);
 
+        if (!headlessControlSupported || headless == null) {
+            return;
+        }
+
         try {
             headless.set(null, isHeadless);
         } catch (IllegalAccessException e) {
-            //this should never happen. if it doesn't work, then all GUI tests would be messed up :(
-            throw new RuntimeException("ERROR: failed to change AWT Headless state: " + e.getMessage(), e);
+            logger.warn("Failed to change AWT headless state reflectively: {}", e.getMessage());
         }
 
     }

--- a/runtime/src/main/java/org/evosuite/runtime/classhandling/JDKClassResetter.java
+++ b/runtime/src/main/java/org/evosuite/runtime/classhandling/JDKClassResetter.java
@@ -38,6 +38,7 @@ public class JDKClassResetter {
 
     private static Map renderingHintsKeyIdentityMap;
     private static Map renderingHintsKeyIdentityMapCopy;
+    private static boolean resetSupported;
 
 
     /**
@@ -45,18 +46,26 @@ public class JDKClassResetter {
      */
     public static void init() {
 
+        resetSupported = false;
+        renderingHintsKeyIdentityMap = null;
+        renderingHintsKeyIdentityMapCopy = null;
+
         try {
             Field field = RenderingHints.Key.class.getDeclaredField("identitymap");
             field.setAccessible(true);
             renderingHintsKeyIdentityMap = (Map) field.get(null);
             renderingHintsKeyIdentityMapCopy = new LinkedHashMap<>(renderingHintsKeyIdentityMap.size());
             renderingHintsKeyIdentityMapCopy.putAll(renderingHintsKeyIdentityMap);
+            resetSupported = true;
 
         } catch (Exception e) {
-            //shouldn't really happen
-            logger.error("Failed to handle 'identitymap': " + e);
+            logger.warn("RenderingHints.Key reset is not available on this JDK: {}", e.getMessage());
         }
 
+    }
+
+    public static boolean isResetSupported() {
+        return resetSupported;
     }
 
     public static void reset() {

--- a/runtime/src/main/java/org/evosuite/runtime/instrumentation/MethodCallReplacementMethodAdapter.java
+++ b/runtime/src/main/java/org/evosuite/runtime/instrumentation/MethodCallReplacementMethodAdapter.java
@@ -144,13 +144,13 @@ public class MethodCallReplacementMethodAdapter extends GeneratorAdapter {
 
     @Override
     public void visitMaxs(int maxStack, int maxLocals) {
-        // The instrumentation adds a boolean to the stack at one point
-        // which _may_ increase the max stack size. A ASM
-        // doesn't manage to calculate the maximum stack size
-        // correctly we just add one here
-        if (hasBeenInstrumented)
-            super.visitMaxs(maxStack + 1, maxLocals);
-        else
+        // Modern JDK verifiers are less forgiving about stale stack metadata.
+        // The surrounding instrumentation pipeline uses ASM compute flags, so
+        // relying on ASM's recomputation is safer than keeping a manual +1 hack.
+        if (hasBeenInstrumented) {
+            super.visitMaxs(0, 0);
+        } else {
             super.visitMaxs(maxStack, maxLocals);
+        }
     }
 }

--- a/runtime/src/main/java/org/evosuite/runtime/instrumentation/RuntimeInstrumentation.java
+++ b/runtime/src/main/java/org/evosuite/runtime/instrumentation/RuntimeInstrumentation.java
@@ -112,7 +112,7 @@ public class RuntimeInstrumentation {
                     + classNameWithDots + ")! Load by parent (JVM) classloader.");
         }
 
-        int asmFlags = ClassWriter.COMPUTE_FRAMES;
+        int asmFlags = ClassWriter.COMPUTE_FRAMES | ClassWriter.COMPUTE_MAXS;
         ClassWriter writer = new ComputeClassWriter(asmFlags);
 
         ClassVisitor cv = writer;

--- a/runtime/src/main/java/org/evosuite/runtime/jvm/ShutdownHookHandler.java
+++ b/runtime/src/main/java/org/evosuite/runtime/jvm/ShutdownHookHandler.java
@@ -39,6 +39,7 @@ public class ShutdownHookHandler {
     private static final Logger logger = LoggerFactory.getLogger(ShutdownHookHandler.class);
 
     private static final ShutdownHookHandler instance = new ShutdownHookHandler();
+    private static volatile boolean shutdownHooksSupported = true;
 
     /**
      * A reference to the actual map in the JVM that holds the shutdown
@@ -74,6 +75,7 @@ public class ShutdownHookHandler {
              */
             String msg = "Failed to initialize shutdown hook handling";
             logger.error(msg);
+            shutdownHooksSupported = false;
         }
     }
 
@@ -81,11 +83,15 @@ public class ShutdownHookHandler {
         return instance;
     }
 
+    public boolean isShutdownHookControlSupported() {
+        return shutdownHooksSupported && hooksReference != null;
+    }
+
     /**
      * Important to check what hooks are currently registered
      */
     public void initHandler() {
-        if (hooksReference == null) {
+        if (!isShutdownHookControlSupported()) {
             return; //
         }
 
@@ -108,7 +114,7 @@ public class ShutdownHookHandler {
      * @return
      */
     public List<Thread> getAddedHooks() {
-        if (hooksReference == null || existingHooks == null) {
+        if (!isShutdownHookControlSupported() || existingHooks == null) {
             return null;
         }
 
@@ -128,7 +134,7 @@ public class ShutdownHookHandler {
      * @return
      */
     public int getNumberOfAllExistingHooks() {
-        if (hooksReference == null) {
+        if (!isShutdownHookControlSupported()) {
             return -1;
         }
         return hooksReference.size();

--- a/runtime/src/main/java/org/evosuite/runtime/mock/java/net/Inet4AddressUtil.java
+++ b/runtime/src/main/java/org/evosuite/runtime/mock/java/net/Inet4AddressUtil.java
@@ -19,9 +19,9 @@
  */
 package org.evosuite.runtime.mock.java.net;
 
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Constructor;
 import java.net.Inet4Address;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
 
 
 import org.slf4j.Logger;
@@ -44,51 +44,27 @@ public class Inet4AddressUtil {
 	 */
 	public static final int INADDRSZ = 4;
 	
-	private static Constructor<Inet4Address> constructorStringByteArray;
-	private static Constructor<Inet4Address> constructorStringInt;
-	//private static Field holderField;
-	
-	static{
-		try {
-			constructorStringByteArray = Inet4Address.class.getDeclaredConstructor(String.class, byte[].class);
-			constructorStringByteArray.setAccessible(true);
-			
-			constructorStringInt = Inet4Address.class.getDeclaredConstructor(String.class, int.class);
-			constructorStringInt.setAccessible(true);
-			
-			//holderField = InetAddress.class.getDeclaredField("holder");
-			//holderField.setAccessible(true);
-			
-		} catch (NoSuchMethodException | SecurityException e) { // | NoSuchFieldException e) {
-			logger.error("Failed to initialize due to reflection problems: "+e.getMessage());
-		}
-	}
-	
 	public static Inet4Address createNewInstance(){
-		try {
-			return Inet4Address.class.newInstance();			
-		} catch (InstantiationException | IllegalAccessException e) {
-			logger.error("Failed to create instance: "+e.getMessage());
-		}
-		return null; 
+		return createNewInstance(null, new byte[INADDRSZ]);
 	}
 	
 	public static Inet4Address createNewInstance(String hostName, byte[] addr){
 		try {
-			return constructorStringByteArray.newInstance(hostName,addr);
-		} catch ( SecurityException | InstantiationException | IllegalAccessException | IllegalArgumentException | InvocationTargetException e) {
-			logger.error("Failed to create instance: "+e.getMessage());
+			return (Inet4Address) InetAddress.getByAddress(hostName, addr);
+		} catch (UnknownHostException | ClassCastException e) {
+			logger.error("Failed to create instance: {}", e.getMessage());
 		}
 		return null;
 	}
 	
 	public static Inet4Address createNewInstance(String hostName, int address){
-		try {
-			return constructorStringInt.newInstance(hostName,address);
-		} catch (SecurityException | InstantiationException | IllegalAccessException | IllegalArgumentException | InvocationTargetException e) {
-			logger.error("Failed to create instance: "+e.getMessage());
-		}
-		return null;
+		byte[] addr = new byte[] {
+				(byte) ((address >>> 24) & 0xFF),
+				(byte) ((address >>> 16) & 0xFF),
+				(byte) ((address >>> 8) & 0xFF),
+				(byte) (address & 0xFF)
+		};
+		return createNewInstance(hostName, addr);
 	}
 			
 }

--- a/runtime/src/main/java/org/evosuite/runtime/mock/java/net/MockDatagramSocket.java
+++ b/runtime/src/main/java/org/evosuite/runtime/mock/java/net/MockDatagramSocket.java
@@ -55,18 +55,16 @@ public class MockDatagramSocket extends DatagramSocket implements OverrideMock{
         try {
             m = DatagramSocket.class.getDeclaredMethod("createImpl");
             m.setAccessible(true);
-        } catch (NoSuchMethodException e) {
-            //should never happen
-            logger.error("Failed reflection on DatagramSocket: "+e.getMessage());
+        } catch (NoSuchMethodException | RuntimeException e) {
+            logger.warn("DatagramSocket#createImpl reflection is not available on this JDK: {}", e.getMessage());
         }
 
         Field f = null;
         try {
             f = DatagramSocket.class.getDeclaredField("impl");
             f.setAccessible(true);
-        } catch (NoSuchFieldException e) {
-            //should never happen
-            logger.error("Failed reflection on DatagramSocket: "+e.getMessage());
+        } catch (NoSuchFieldException | RuntimeException e) {
+            logger.warn("DatagramSocket#impl reflection is not available on this JDK: {}", e.getMessage());
         }
 
         CREATE_IMPL = m;
@@ -123,6 +121,9 @@ public class MockDatagramSocket extends DatagramSocket implements OverrideMock{
         super(new EvoDatagramSocketImpl());
 
         if(!MockFramework.isEnabled()){
+            if (IMPL == null || CREATE_IMPL == null) {
+                throw new SocketException("Real DatagramSocket fallback is not supported on this JDK without mock mode");
+            }
             try {
                 IMPL.set(this, null);
                 CREATE_IMPL.invoke(this);
@@ -152,6 +153,9 @@ public class MockDatagramSocket extends DatagramSocket implements OverrideMock{
         super(new EvoDatagramSocketImpl());
 
         if(!MockFramework.isEnabled()){
+            if (IMPL == null || CREATE_IMPL == null) {
+                throw new SocketException("Real DatagramSocket fallback is not supported on this JDK without mock mode");
+            }
             try {
                 IMPL.set(this, null);
                 CREATE_IMPL.invoke(this);

--- a/runtime/src/main/java/org/evosuite/runtime/mock/java/net/MockURL.java
+++ b/runtime/src/main/java/org/evosuite/runtime/mock/java/net/MockURL.java
@@ -19,6 +19,7 @@
  */
 package org.evosuite.runtime.mock.java.net;
 
+import java.io.IOException;
 import java.io.InputStream;
 import java.lang.reflect.InvocationTargetException;
 import java.net.MalformedURLException;
@@ -105,20 +106,11 @@ public class MockURL implements StaticReplacementMock{
 	public static URL URL(String protocol, String host, int port, String file,
 			URLStreamHandler handler) throws MalformedURLException {
 
+		if(handler == null){
+			handler = getMockedURLStreamHandler(protocol);
+		}
 
 		URL url = new URL(protocol,host,port,file,handler);
-
-		//we just need to deal with "handler" if it wasn't specified
-		if(handler == null){
-			/*
-			 * if no handler is specified, then parent would load one based on 
-			 * protocol. As the function there is package level, we cannot modify/override it,
-			 * and we still have to call a constructor.
-			 * So, just replace the handler via reflection
-			 */
-			handler = getMockedURLStreamHandler(protocol);
-			URLUtil.setHandler(url, handler);
-		}
 
 		return url;
 	}
@@ -127,92 +119,26 @@ public class MockURL implements StaticReplacementMock{
 	public static URL URL(URL context, String spec, URLStreamHandler handler)
 			throws MalformedURLException{
 
+		if(handler == null){
+			String protocol = null;
+			if (context != null) {
+				protocol = context.getProtocol();
+			}
+			if (protocol == null || protocol.trim().isEmpty()) {
+				int protocolSeparator = spec.indexOf(':');
+				if (protocolSeparator > 0) {
+					protocol = spec.substring(0, protocolSeparator);
+				}
+			}
+
+			if (protocol != null && !protocol.trim().isEmpty()) {
+				handler = getMockedURLStreamHandler(protocol);
+			}
+		}
+
 		URL url = new URL(context,spec,handler);
 
-		//we just need to deal with "handler" if it wasn't specified
-		if(handler == null){
-			/*
-			 * if no handler is specified, then parent would load one based on 
-			 * protocol. As the function there is package level, we cannot modify/override it,
-			 * and we still have to call a constructor.
-			 * So, just replace the handler via reflection
-			 */
-			handler = getMockedURLStreamHandler(url.getProtocol());
-			URLUtil.setHandler(url, handler);
-
-			//this is needed, as called on the handler in the constructor we are mocking
-			handleParseUrl(url,spec,handler);
-		}
-
 		return url;
-	}
-
-
-
-	private static void handleParseUrl(URL url, String spec, URLStreamHandler handler) throws MalformedURLException {
-
-		//code here is based on URL constructor
-
-		int i, limit, c;
-		int start = 0;
-		boolean aRef=false;
-
-		limit = spec.length();
-		while ((limit > 0) && (spec.charAt(limit - 1) <= ' ')) {
-			limit--;        //eliminate trailing whitespace
-		}
-		while ((start < limit) && (spec.charAt(start) <= ' ')) {
-			start++;        // eliminate leading whitespace
-		}
-
-		if (spec.regionMatches(true, start, "url:", 0, 4)) {
-			start += 4;
-		}
-
-		if (start < spec.length() && spec.charAt(start) == '#') {
-			aRef=true;
-		}
-
-		for (i = start; !aRef && (i < limit) &&
-				((c = spec.charAt(i)) != '/'); i++) {
-			if (c == ':') {
-
-				String s = spec.substring(start, i).toLowerCase();
-				if (isValidProtocol(s)) {
-					start = i + 1;
-				}
-				break;
-			}
-		}
-
-		i = spec.indexOf('#', start);
-		if (i >= 0) {
-			limit = i;
-		}
-
-        try {
-            URLStreamHandlerUtil.parseURL(handler, url, spec, start, limit);
-        } catch (InvocationTargetException e) {
-           throw new MalformedURLException(e.getCause().toString());
-        }
-    }
-
-	//From URL
-	private static boolean isValidProtocol(String protocol) {
-		int len = protocol.length();
-		if (len < 1)
-			return false;
-		char c = protocol.charAt(0);
-		if (!Character.isLetter(c))
-			return false;
-		for (int i = 1; i < len; i++) {
-			c = protocol.charAt(i);
-			if (!Character.isLetterOrDigit(c) && c != '.' && c != '+' &&
-					c != '-') {
-				return false;
-			}
-		}
-		return true;
 	}
 
 	// ---------------------
@@ -315,13 +241,11 @@ public class MockURL implements StaticReplacementMock{
 			throw new IllegalArgumentException("proxy can not be null");
 		}
 
-		// Create a copy of Proxy as a security measure
-		//Proxy p = proxy == Proxy.NO_PROXY ? Proxy.NO_PROXY : sun.net.ApplicationProxy.create(proxy);
-        try {
-            return URLStreamHandlerUtil.openConnection(URLUtil.getHandler(url), url, proxy);
-        } catch (InvocationTargetException e) {
-            throw new MockIOException(e.getCause());
-        }
+		try {
+			return url.openConnection(proxy);
+		} catch (IOException e) {
+			throw new MockIOException(e);
+		}
     }
 
 

--- a/runtime/src/main/java/org/evosuite/runtime/mock/java/net/MockURLStreamHandler.java
+++ b/runtime/src/main/java/org/evosuite/runtime/mock/java/net/MockURLStreamHandler.java
@@ -41,22 +41,18 @@ public abstract class MockURLStreamHandler extends URLStreamHandler implements O
             return super.getHostAddress(u);
         }
 
-        if (URLUtil.getHostAddress(u) != null)
-			return URLUtil.getHostAddress(u);
-
 		String host = u.getHost();
 		if (host == null || host.equals("")) {
 			return null;
 		} else {
 			try {
-				URLUtil.setHostAddress(u, MockInetAddress.getByName(host));
+				return MockInetAddress.getByName(host);
 			} catch (UnknownHostException ex) {
 				return null;
 			} catch (SecurityException se) {
 				return null;
 			}
 		}
-		return URLUtil.getHostAddress(u);
 	}
 
 	/*

--- a/runtime/src/main/java/org/evosuite/runtime/mock/java/net/NetReflectionUtil.java
+++ b/runtime/src/main/java/org/evosuite/runtime/mock/java/net/NetReflectionUtil.java
@@ -21,6 +21,7 @@ package org.evosuite.runtime.mock.java.net;
 
 import java.lang.reflect.Method;
 import java.net.InetAddress;
+import java.net.UnknownHostException;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -42,16 +43,24 @@ public class NetReflectionUtil {
 	 * @return
 	 */
 	public static InetAddress anyLocalAddress(){
-				
+		InetAddress loopback = InetAddress.getLoopbackAddress();
+		if (loopback != null) {
+			return loopback;
+		}
+
 		try {
 			Method m = InetAddress.class.getDeclaredMethod("anyLocalAddress");
 			m.setAccessible(true);
 			return (InetAddress) m.invoke(null);
 		} catch (Exception e) {
-			//should never happen
-			logger.error("Failed to use reflection on InetAddress.anyLocalAddress(): "+e.getMessage(),e);
+			logger.debug("Failed to use reflection on InetAddress.anyLocalAddress(): {}", e.getMessage());
 		} 
-		
-		return null;
+
+		try {
+			return InetAddress.getByAddress(new byte[]{0, 0, 0, 0});
+		} catch (UnknownHostException e) {
+			logger.error("Failed to resolve a fallback any-local address: {}", e.getMessage(), e);
+			return null;
+		}
 	}
 }

--- a/runtime/src/main/java/org/evosuite/runtime/mock/java/text/MockDateFormat.java
+++ b/runtime/src/main/java/org/evosuite/runtime/mock/java/text/MockDateFormat.java
@@ -98,6 +98,6 @@ public class MockDateFormat implements StaticReplacementMock {
     }
 
     public static Locale[] getAvailableLocales() {
-        return DateFormat.getAvailableLocales();
+        return Locale.getAvailableLocales();
     }
 }

--- a/runtime/src/main/java/org/evosuite/runtime/mock/java/util/MockCalendar.java
+++ b/runtime/src/main/java/org/evosuite/runtime/mock/java/util/MockCalendar.java
@@ -21,7 +21,6 @@ package org.evosuite.runtime.mock.java.util;
 
 import org.evosuite.runtime.mock.OverrideMock;
 
-import java.text.DateFormat;
 import java.util.*;
 
 /**
@@ -70,8 +69,7 @@ public abstract class MockCalendar extends Calendar implements OverrideMock{
 
 
     public static synchronized Locale[] getAvailableLocales(){
-        //TODO do we need to mock it?
-        return DateFormat.getAvailableLocales();
+        return Calendar.getAvailableLocales();
     }
 
 

--- a/runtime/src/main/java/org/evosuite/runtime/sandbox/MSecurityManager.java
+++ b/runtime/src/main/java/org/evosuite/runtime/sandbox/MSecurityManager.java
@@ -119,8 +119,6 @@ public class MSecurityManager extends SecurityManager {
      * Note: we need to mark for deletion _after_ test execution, otherwise
      * we can end up in a infinite recursion.
      */
-    private final Set<File> filesToDelete;
-
     static {
         File tmp = null;
         try {
@@ -143,22 +141,7 @@ public class MSecurityManager extends SecurityManager {
 
     private final SecurityManager defaultManager;
 
-    /**
-     * Is EvoSuite executing a test case?
-     */
-    private volatile boolean executingTestCase;
-
-
-    /**
-     * Data structure containing all the (EvoSuite) threads that do not need to
-     * go through the same sandbox as the SUT threads
-     */
-    private final Set<Thread> privilegedThreads;
-
-    /**
-     * Check whether a privileged thread should use the sandbox as for SUT code
-     */
-    private volatile Thread privilegedThreadToIgnore;
+    private final SandboxContext context;
 
     /**
      * Name of all the methods in the MasterNodeRemote interface.
@@ -168,6 +151,7 @@ public class MSecurityManager extends SecurityManager {
     private static Set<String> masterNodeRemoteMethodNames;
 
     private static boolean runningClientOnThread = false;
+    private static volatile Boolean securityManagerSupported;
 
     /**
      * It can happen that EvoSuite encounters permissions it does not recognize.
@@ -182,14 +166,35 @@ public class MSecurityManager extends SecurityManager {
      * instance is automatically added as "privileged"
      */
     public MSecurityManager() {
-        privilegedThreads = new CopyOnWriteArraySet<>();
-        privilegedThreads.add(Thread.currentThread());
-        defaultManager = System.getSecurityManager();
-        executingTestCase = false;
-        privilegedThreadToIgnore = null;
-        unrecognizedPermissions = new CopyOnWriteArraySet<>();
+        this(new SandboxContext());
+    }
 
-        filesToDelete = new CopyOnWriteArraySet<>();
+    MSecurityManager(SandboxContext context) {
+        this.context = context;
+        defaultManager = System.getSecurityManager();
+        unrecognizedPermissions = new CopyOnWriteArraySet<>();
+    }
+
+    public static boolean isSecurityManagerSupported() {
+        Boolean cached = securityManagerSupported;
+        if (cached != null) {
+            return cached;
+        }
+
+        synchronized (MSecurityManager.class) {
+            if (securityManagerSupported != null) {
+                return securityManagerSupported;
+            }
+
+            SecurityManager current = System.getSecurityManager();
+            try {
+                System.setSecurityManager(current);
+                securityManagerSupported = true;
+            } catch (UnsupportedOperationException e) {
+                securityManagerSupported = false;
+            }
+            return securityManagerSupported;
+        }
     }
 
     /**
@@ -208,8 +213,7 @@ public class MSecurityManager extends SecurityManager {
     }
 
     public Set<Thread> getPrivilegedThreads() {
-        Set<Thread> set = new LinkedHashSet<>(privilegedThreads);
-        return set;
+        return context.getPrivilegedThreads();
     }
 
     public static void setRunningClientOnThread(boolean runningClientOnThread) {
@@ -236,13 +240,7 @@ public class MSecurityManager extends SecurityManager {
      * @throws IllegalStateException
      */
     public void goingToExecuteUnsafeCodeOnSameThread() throws SecurityException, IllegalStateException {
-        if (!privilegedThreads.contains(Thread.currentThread())) {
-            throw new SecurityException("Current thread is not privileged");
-        }
-        if (privilegedThreadToIgnore != null) {
-            throw new IllegalStateException("The thread is already executing unsafe code");
-        }
-        privilegedThreadToIgnore = Thread.currentThread();
+        context.goingToExecuteUnsafeCodeOnSameThread();
     }
 
     /**
@@ -252,14 +250,7 @@ public class MSecurityManager extends SecurityManager {
      * @return
      */
     public boolean isSafeToExecuteSUTCode() {
-        Thread current = Thread.currentThread();
-        if (!privilegedThreads.contains(current)) {
-            //the thread is not privileged, so run inside the box
-            return true;
-        } else {
-            // this can happen if the thread is privileged, but already running SUT code
-            return privilegedThreadToIgnore == current;
-        }
+        return context.isSafeToExecuteSUTCode();
     }
 
     /**
@@ -271,14 +262,7 @@ public class MSecurityManager extends SecurityManager {
      */
     public void doneWithExecutingUnsafeCodeOnSameThread() throws SecurityException,
             IllegalStateException {
-        if (!privilegedThreads.contains(Thread.currentThread())) {
-            throw new SecurityException(
-                    "Only a privileged thread can return from unsafe code execution");
-        }
-        if (privilegedThreadToIgnore == null) {
-            throw new IllegalStateException("The thread was not executing unsafe code");
-        }
-        privilegedThreadToIgnore = null;
+        context.doneWithExecutingUnsafeCodeOnSameThread();
     }
 
     /**
@@ -318,9 +302,12 @@ public class MSecurityManager extends SecurityManager {
      * @throws IllegalStateException
      */
     public void apply() throws IllegalStateException {
+        if (!isSecurityManagerSupported()) {
+            throw new IllegalStateException("SecurityManager is not supported on this JDK");
+        }
         try {
             System.setSecurityManager(this);
-        } catch (SecurityException e) {
+        } catch (SecurityException | UnsupportedOperationException e) {
             // this should never happen in EvoSuite, ie this object should be created just once
             logger.error("Cannot instantiate mock security manager", e);
             throw new IllegalStateException(e);
@@ -331,38 +318,22 @@ public class MSecurityManager extends SecurityManager {
      * Note: an un-privileged thread would throw a security exception
      */
     public void restoreDefaultManager() throws SecurityException {
+        if (!isSecurityManagerSupported()) {
+            return;
+        }
         System.setSecurityManager(defaultManager);
     }
 
     public void goingToExecuteTestCase() throws IllegalStateException {
-        if (executingTestCase) {
-            throw new IllegalStateException("Trying to set up the sandbox while executing a test case");
-        }
-
-        executingTestCase = true;
+        context.goingToExecuteTestCase();
     }
 
     public boolean isExecutingTestCase() {
-        return executingTestCase;
+        return context.isExecutingTestCase();
     }
 
     public void goingToEndTestCase() throws IllegalStateException {
-        if (!executingTestCase) {
-            throw new IllegalStateException("Trying to disable sandbox when not test case was run");
-        }
-
-        /*
-         * it is important to call this method here as soon as the test case
-         * has finished executing, because properties could be used by
-         * EvoSuite as well
-         */
-        org.evosuite.runtime.System.restoreProperties();
-
-        for (File file : filesToDelete) {
-            file.deleteOnExit();
-        }
-
-        executingTestCase = false;
+        context.goingToEndTestCase();
     }
 
     /**
@@ -373,14 +344,14 @@ public class MSecurityManager extends SecurityManager {
      * @throws SecurityException if the thread calling this method is not privileged itself
      */
     public synchronized void addPrivilegedThread(Thread t) throws SecurityException {
-        if (privilegedThreads.contains(Thread.currentThread())) {
+        if (context.isPrivilegedThread(Thread.currentThread())) {
             logger.debug("Adding privileged thread: \"" + t.getName() + "\"");
-            privilegedThreads.add(t);
+            context.addPrivilegedThread(t);
         } else {
             String current = Thread.currentThread().getName();
             String msg = "Unprivileged thread \"" + current + "\" cannot add a privileged thread: failed to add \"" + t.getName() + "\"";
             msg += "\nCurrent privileged threads are: ";
-            for (Thread p : privilegedThreads) {
+            for (Thread p : context.getPrivilegedThreads()) {
                 msg += "\n\"" + p.getName() + "\"";
             }
             throw new SecurityException(msg);
@@ -424,7 +395,7 @@ public class MSecurityManager extends SecurityManager {
             for (StackTraceElement e : Thread.currentThread().getStackTrace()) {
                 stack += e + "\n";
             }
-            if (executingTestCase) {
+            if (context.isExecutingTestCase()) {
                 /*
                  * report statistics only during test case execution, although still log them. The reason is to avoid EvoSuite threads which might not
                  * privileged to mess up with the statistics on the SUT
@@ -435,7 +406,7 @@ public class MSecurityManager extends SecurityManager {
 
             throw new SecurityException("Security manager blocks " + perm + stack);
         } else {
-            if (executingTestCase) {
+            if (context.isExecutingTestCase()) {
                 statistics.permissionAllowed(perm);
             }
         }
@@ -496,11 +467,11 @@ public class MSecurityManager extends SecurityManager {
         }
 
         // first check if calling thread belongs to EvoSuite rather than the SUT
-        if (privilegedThreads.contains(Thread.currentThread())) {
+        if (context.isPrivilegedThread(Thread.currentThread())) {
 
             //it is an EvoSuite thread but, in special occasions, we might want to ignore its privileged status
 
-            if (privilegedThreadToIgnore == null || !Thread.currentThread().equals(privilegedThreadToIgnore)) {
+            if (context.getPrivilegedThreadToIgnore() == null || !Thread.currentThread().equals(context.getPrivilegedThreadToIgnore())) {
 
                 if (defaultManager == null) {
                     return true; // no security manager, so allow it
@@ -1175,7 +1146,7 @@ public class MSecurityManager extends SecurityManager {
             return true;
         }
 
-        if (perm.getActions().contains("write") && !executingTestCase) {
+        if (perm.getActions().contains("write") && !context.isExecutingTestCase()) {
             return !org.evosuite.runtime.System.isSystemProperty(perm.getName());
         }
 

--- a/runtime/src/main/java/org/evosuite/runtime/sandbox/Sandbox.java
+++ b/runtime/src/main/java/org/evosuite/runtime/sandbox/Sandbox.java
@@ -30,6 +30,18 @@ import java.util.Set;
  */
 public class Sandbox {
 
+    public enum SandboxStatus {
+        OFF,
+        COORDINATION_ONLY,
+        LEGACY_ENFORCEMENT
+    }
+
+    public enum EnforcementCapability {
+        NONE,
+        LEGACY_SECURITY_MANAGER,
+        ISOLATED_PROCESS
+    }
+
     public enum SandboxMode {
         OFF, RECOMMENDED, IO
     }
@@ -37,6 +49,7 @@ public class Sandbox {
     private static final Logger logger = LoggerFactory.getLogger(Sandbox.class);
 
     private static volatile MSecurityManager manager;
+    private static volatile SandboxContext context;
 
     /**
      * count how often we tried to init the sandbox.
@@ -59,20 +72,25 @@ public class Sandbox {
      * Create and initialize security manager for SUT
      */
     public static synchronized void initializeSecurityManagerForSUT(Set<Thread> privileged) {
-        if (manager == null) {
-            manager = new MSecurityManager();
+        if (context == null) {
+            context = new SandboxContext();
 
             if (privileged == null) {
-                manager.makePrivilegedAllCurrentThreads();
+                makePrivilegedAllCurrentThreads(context);
             } else {
                 for (Thread t : privileged) {
-                    manager.addPrivilegedThread(t);
+                    context.addPrivilegedThread(t);
                 }
             }
-
-            manager.apply();
         } else {
             logger.warn("Sandbox can be initalized only once");
+        }
+
+        if (MSecurityManager.isSecurityManagerSupported() && manager == null) {
+            manager = new MSecurityManager(context);
+            manager.apply();
+        } else if (!MSecurityManager.isSecurityManagerSupported()) {
+            logger.warn("Sandbox security manager is not supported on this JDK; running with coordination-only sandbox mode");
         }
 
         counter++;
@@ -86,8 +104,9 @@ public class Sandbox {
     }
 
     public static void addPrivilegedThread(Thread t) {
-        if (manager != null)
-            manager.addPrivilegedThread(t);
+        if (context != null) {
+            context.addPrivilegedThread(t);
+        }
     }
 
     /**
@@ -95,10 +114,9 @@ public class Sandbox {
      * if then we want to reactivate the security manager with the same priviliged threads.
      */
     public static synchronized Set<Thread> resetDefaultSecurityManager() {
-
         Set<Thread> privileged = null;
-        if (manager != null) {
-            privileged = manager.getPrivilegedThreads();
+        if (context != null) {
+            privileged = context.getPrivilegedThreads();
         }
 
         counter--;
@@ -108,13 +126,44 @@ public class Sandbox {
                 manager.restoreDefaultManager();
             }
             manager = null;
+            context = null;
+            counter = 0;
         }
 
         return privileged;
     }
 
     public static boolean isSecurityManagerInitialized() {
+        return context != null;
+    }
+
+    public static boolean isSandboxInitialized() {
+        return context != null;
+    }
+
+    public static boolean isEnforcingPermissions() {
         return manager != null;
+    }
+
+    public static boolean isLegacySecurityManagerSupported() {
+        return MSecurityManager.isSecurityManagerSupported();
+    }
+
+    public static EnforcementCapability getEnforcementCapability() {
+        if (manager != null) {
+            return EnforcementCapability.LEGACY_SECURITY_MANAGER;
+        }
+        return EnforcementCapability.NONE;
+    }
+
+    public static SandboxStatus getSandboxStatus() {
+        if (context == null) {
+            return SandboxStatus.OFF;
+        }
+        if (manager != null) {
+            return SandboxStatus.LEGACY_ENFORCEMENT;
+        }
+        return SandboxStatus.COORDINATION_ONLY;
     }
 
     public static void goingToExecuteSUTCode() {
@@ -124,7 +173,7 @@ public class Sandbox {
             }
             return;
         }
-        manager.goingToExecuteTestCase();
+        context.goingToExecuteTestCase();
         PermissionStatistics.getInstance().getAndResetExceptionInfo();
     }
 
@@ -135,14 +184,14 @@ public class Sandbox {
             }
             return;
         }
-        manager.goingToEndTestCase();
+        context.goingToEndTestCase();
     }
 
     public static boolean isOnAndExecutingSUTCode() {
         if (!isSecurityManagerInitialized()) {
             return false;
         }
-        return manager.isExecutingTestCase();
+        return context.isExecutingTestCase();
     }
 
     public static void goingToExecuteUnsafeCodeOnSameThread() throws SecurityException,
@@ -150,7 +199,7 @@ public class Sandbox {
         if (!isSecurityManagerInitialized()) {
             return;
         }
-        manager.goingToExecuteUnsafeCodeOnSameThread();
+        context.goingToExecuteUnsafeCodeOnSameThread();
     }
 
     public static void doneWithExecutingUnsafeCodeOnSameThread()
@@ -158,7 +207,7 @@ public class Sandbox {
         if (!isSecurityManagerInitialized()) {
             return;
         }
-        manager.doneWithExecutingUnsafeCodeOnSameThread();
+        context.doneWithExecutingUnsafeCodeOnSameThread();
     }
 
 
@@ -166,6 +215,25 @@ public class Sandbox {
         if (!isSecurityManagerInitialized()) {
             return false;
         }
-        return manager.isSafeToExecuteSUTCode();
+        return context.isSafeToExecuteSUTCode();
+    }
+
+    static SandboxContext getContext() {
+        return context;
+    }
+
+    private static void makePrivilegedAllCurrentThreads(SandboxContext sandboxContext) {
+        ThreadGroup root = Thread.currentThread().getThreadGroup();
+        while (root.getParent() != null) {
+            root = root.getParent();
+        }
+
+        Thread[] threads = new Thread[root.activeCount() + 10];
+        root.enumerate(threads);
+        for (Thread t : threads) {
+            if (t != null) {
+                sandboxContext.addPrivilegedThread(t);
+            }
+        }
     }
 }

--- a/runtime/src/main/java/org/evosuite/runtime/sandbox/SandboxContext.java
+++ b/runtime/src/main/java/org/evosuite/runtime/sandbox/SandboxContext.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright (C) 2010-2018 Gordon Fraser, Andrea Arcuri and EvoSuite
+ * contributors
+ *
+ * This file is part of EvoSuite.
+ *
+ * EvoSuite is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3.0 of the License, or
+ * (at your option) any later version.
+ *
+ * EvoSuite is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with EvoSuite. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.evosuite.runtime.sandbox;
+
+import java.io.File;
+import java.util.LinkedHashSet;
+import java.util.Set;
+import java.util.concurrent.CopyOnWriteArraySet;
+
+/**
+ * Shared sandbox execution state. This is intentionally independent of
+ * SecurityManager so we can coordinate SUT execution even on modern JDKs.
+ */
+class SandboxContext {
+
+    private final Set<Thread> privilegedThreads;
+    private final Set<File> filesToDelete;
+
+    private volatile boolean executingTestCase;
+    private volatile Thread privilegedThreadToIgnore;
+
+    SandboxContext() {
+        privilegedThreads = new CopyOnWriteArraySet<>();
+        privilegedThreads.add(Thread.currentThread());
+        filesToDelete = new CopyOnWriteArraySet<>();
+        executingTestCase = false;
+        privilegedThreadToIgnore = null;
+    }
+
+    Set<Thread> getPrivilegedThreads() {
+        return new LinkedHashSet<>(privilegedThreads);
+    }
+
+    Set<File> getFilesToDelete() {
+        return filesToDelete;
+    }
+
+    synchronized void addPrivilegedThread(Thread thread) {
+        privilegedThreads.add(thread);
+    }
+
+    boolean isPrivilegedThread(Thread thread) {
+        return privilegedThreads.contains(thread);
+    }
+
+    Thread getPrivilegedThreadToIgnore() {
+        return privilegedThreadToIgnore;
+    }
+
+    synchronized void goingToExecuteUnsafeCodeOnSameThread() {
+        if (!isPrivilegedThread(Thread.currentThread())) {
+            throw new SecurityException("Current thread is not privileged");
+        }
+        if (privilegedThreadToIgnore != null) {
+            throw new IllegalStateException("The thread is already executing unsafe code");
+        }
+        privilegedThreadToIgnore = Thread.currentThread();
+    }
+
+    synchronized void doneWithExecutingUnsafeCodeOnSameThread() {
+        if (!isPrivilegedThread(Thread.currentThread())) {
+            throw new SecurityException(
+                    "Only a privileged thread can return from unsafe code execution");
+        }
+        if (privilegedThreadToIgnore == null) {
+            throw new IllegalStateException("The thread was not executing unsafe code");
+        }
+        privilegedThreadToIgnore = null;
+    }
+
+    boolean isSafeToExecuteSUTCode() {
+        Thread current = Thread.currentThread();
+        if (!isPrivilegedThread(current)) {
+            return true;
+        }
+        return privilegedThreadToIgnore == current;
+    }
+
+    synchronized void goingToExecuteTestCase() {
+        if (executingTestCase) {
+            throw new IllegalStateException("Trying to set up the sandbox while executing a test case");
+        }
+        executingTestCase = true;
+    }
+
+    boolean isExecutingTestCase() {
+        return executingTestCase;
+    }
+
+    synchronized void goingToEndTestCase() {
+        if (!executingTestCase) {
+            throw new IllegalStateException("Trying to disable sandbox when not test case was run");
+        }
+        org.evosuite.runtime.System.restoreProperties();
+        for (File file : filesToDelete) {
+            file.deleteOnExit();
+        }
+        executingTestCase = false;
+    }
+}

--- a/runtime/src/main/java/org/evosuite/runtime/util/JavaExecCmdUtil.java
+++ b/runtime/src/main/java/org/evosuite/runtime/util/JavaExecCmdUtil.java
@@ -46,18 +46,26 @@ public class JavaExecCmdUtil {
      * @apiNote under maven java.home property is ${JAVA_HOME}/jre/bin/java
      */
     public static String getJavaBinExecutablePath(final boolean isFullOriginalJavaExecRequired) {
-        final String JAVA_CMD = Paths.get(System.getProperty("java.home"), "bin", "java").toString();
+        return getJavaBinExecutablePath(
+                getJavaHomeEnv().orElse(null),
+                getOsName().orElse(null),
+                System.getProperty("java.home"),
+                isFullOriginalJavaExecRequired
+        );
+    }
 
-        return getJavaHomeEnv()
-                .map(javaHomeEnvVar ->
-                     Paths.get(javaHomeEnvVar, "bin", "java", getOsName()
-                               .filter(osName -> osName.toLowerCase().contains("windows"))
-                               .map(osName -> ".exe")
-                               .orElse("")).toFile()
-                )
+    static String getJavaBinExecutablePath(final String javaHomeEnv, final String osName,
+                                           final String javaHome, final boolean isFullOriginalJavaExecRequired) {
+        final String javaCmd = Paths.get(javaHome, "bin", "java").toString();
+        final String executableName = osName != null && osName.toLowerCase().contains("windows")
+                ? "java.exe"
+                : "java";
+
+        return Optional.ofNullable(javaHomeEnv)
+                .map(javaHomeEnvVar -> Paths.get(javaHomeEnvVar, "bin", executableName).toFile())
                 .filter(File::exists)
                 .map(File::getPath)
-                .orElse(isFullOriginalJavaExecRequired ? JAVA_CMD : "java");
+                .orElse(isFullOriginalJavaExecRequired ? javaCmd : "java");
     }
 
     /**

--- a/runtime/src/main/java/org/evosuite/runtime/vnet/NetworkInterfaceState.java
+++ b/runtime/src/main/java/org/evosuite/runtime/vnet/NetworkInterfaceState.java
@@ -48,17 +48,22 @@ public class NetworkInterfaceState {
     private final static Field indexField;
 
     static {
+        Constructor<NetworkInterface> networkInterfaceConstructor = null;
+        Field networkInterfaceNameField = null;
+        Field networkInterfaceIndexField = null;
         try {
-            constructor = NetworkInterface.class.getDeclaredConstructor();
-            constructor.setAccessible(true);
-            nameField = NetworkInterface.class.getDeclaredField("name");
-            nameField.setAccessible(true);
-            indexField = NetworkInterface.class.getDeclaredField("index");
-            indexField.setAccessible(true);
-        } catch (NoSuchMethodException | NoSuchFieldException e) {
-            //shouldn't really happen
-            throw new RuntimeException("Bug: failed to init " + NetworkInterfaceState.class + ": " + e.getMessage());
+            networkInterfaceConstructor = NetworkInterface.class.getDeclaredConstructor();
+            networkInterfaceConstructor.setAccessible(true);
+            networkInterfaceNameField = NetworkInterface.class.getDeclaredField("name");
+            networkInterfaceNameField.setAccessible(true);
+            networkInterfaceIndexField = NetworkInterface.class.getDeclaredField("index");
+            networkInterfaceIndexField.setAccessible(true);
+        } catch (NoSuchMethodException | NoSuchFieldException | RuntimeException e) {
+            logger.warn("Synthetic NetworkInterface creation is not available on this JDK: {}", e.getMessage());
         }
+        constructor = networkInterfaceConstructor;
+        nameField = networkInterfaceNameField;
+        indexField = networkInterfaceIndexField;
     }
 
     private NetworkInterface ni;
@@ -66,6 +71,20 @@ public class NetworkInterfaceState {
     private final byte[] mac;
     private final int mtu;
     private final boolean loopback;
+
+    public NetworkInterfaceState(
+            NetworkInterface networkInterface,
+            byte[] mac,
+            int mtu,
+            boolean loopback,
+            InetAddress anAddress) {
+
+        this.mtu = mtu;
+        this.loopback = loopback;
+        this.mac = mac != null ? mac.clone() : null;
+        localAddresses = Collections.singletonList(anAddress);
+        ni = networkInterface;
+    }
 
     public NetworkInterfaceState(
             String name,
@@ -80,6 +99,10 @@ public class NetworkInterfaceState {
         this.mac = mac != null ? mac.clone() : null;
         // for now, we just consider one (IPv4) address per interface
         localAddresses = Collections.singletonList(anAddress);
+
+        if (constructor == null || nameField == null || indexField == null) {
+            throw new IllegalStateException("Synthetic NetworkInterface creation is not supported on this JDK");
+        }
 
         try {
             ni = constructor.newInstance();

--- a/runtime/src/main/java/org/evosuite/runtime/vnet/VirtualNetwork.java
+++ b/runtime/src/main/java/org/evosuite/runtime/vnet/VirtualNetwork.java
@@ -26,6 +26,8 @@ import java.io.IOException;
 import java.net.DatagramPacket;
 import java.net.InetAddress;
 import java.net.MalformedURLException;
+import java.net.NetworkInterface;
+import java.net.SocketException;
 import java.net.URL;
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
@@ -533,18 +535,36 @@ public class VirtualNetwork {
     private void initNetworkInterfaces() {
 
         try {
+            NetworkInterface loopbackInterface = getPreferredInterface(true);
             NetworkInterfaceState loopback = new NetworkInterfaceState(
-                    "Evo_lo0", 1, null, 16384, true, MockInetAddress.getByName("127.0.0.1"));
+                    loopbackInterface, null, 16384, true, MockInetAddress.getByName("127.0.0.1"));
             networkInterfaces.add(loopback);
 
+            NetworkInterface nonLoopbackInterface = getPreferredInterface(false);
             NetworkInterfaceState wifi = new NetworkInterfaceState(
-                    "Evo_en0", 5, new byte[]{0, 42, 0, 42, 0, 42},
+                    nonLoopbackInterface, new byte[]{0, 42, 0, 42, 0, 42},
                     1500, false, MockInetAddress.getByName("192.168.1.42"));
             networkInterfaces.add(wifi);
         } catch (Exception e) {
             //this should never happen
             throw new RuntimeException("EvoSuite error: " + e.getMessage());
         }
+    }
+
+    private NetworkInterface getPreferredInterface(boolean loopback) throws SocketException {
+        Enumeration<NetworkInterface> interfaces = NetworkInterface.getNetworkInterfaces();
+        if (interfaces == null) {
+            throw new SocketException("No network interfaces available on host JVM");
+        }
+
+        while (interfaces.hasMoreElements()) {
+            NetworkInterface networkInterface = interfaces.nextElement();
+            if (networkInterface.isLoopback() == loopback) {
+                return networkInterface;
+            }
+        }
+
+        throw new SocketException("Could not find a " + (loopback ? "loopback" : "non-loopback") + " network interface");
     }
 
     //------------------------------------------

--- a/runtime/src/test/java/org/evosuite/runtime/GuiSupportTest.java
+++ b/runtime/src/test/java/org/evosuite/runtime/GuiSupportTest.java
@@ -43,6 +43,7 @@ public class GuiSupportTest {
     @Test
     public void testWhenNotHeadless() {
         Assume.assumeTrue(!GraphicsEnvironment.isHeadless());
+        Assume.assumeTrue(GuiSupport.isHeadlessControlSupported());
 
         GuiSupport.setHeadless();
         Assert.assertTrue(GraphicsEnvironment.isHeadless());

--- a/runtime/src/test/java/org/evosuite/runtime/classhandling/JDKClassResetterTest.java
+++ b/runtime/src/test/java/org/evosuite/runtime/classhandling/JDKClassResetterTest.java
@@ -20,6 +20,7 @@
 package org.evosuite.runtime.classhandling;
 
 
+import org.junit.Assume;
 import org.junit.Test;
 
 import java.awt.*;
@@ -47,6 +48,7 @@ public class JDKClassResetterTest {
     public void testReset() throws Exception {
 
         JDKClassResetter.init();
+        Assume.assumeTrue(JDKClassResetter.isResetSupported());
         int keyValue = 1234567;
 
         //this should be fine

--- a/runtime/src/test/java/org/evosuite/runtime/jvm/ShutdownHookHandlerTest.java
+++ b/runtime/src/test/java/org/evosuite/runtime/jvm/ShutdownHookHandlerTest.java
@@ -21,6 +21,7 @@ package org.evosuite.runtime.jvm;
 
 import org.junit.After;
 import org.junit.Assert;
+import org.junit.Assume;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -29,6 +30,7 @@ public class ShutdownHookHandlerTest {
 
     @Before
     public void init() {
+        Assume.assumeTrue(ShutdownHookHandler.getInstance().isShutdownHookControlSupported());
         ShutdownHookHandler.getInstance().initHandler();
     }
 

--- a/runtime/src/test/java/org/evosuite/runtime/sandbox/MSecurityManagerTest.java
+++ b/runtime/src/test/java/org/evosuite/runtime/sandbox/MSecurityManagerTest.java
@@ -31,26 +31,35 @@ public class MSecurityManagerTest {
 
     private static ExecutorService executor;
     private static MSecurityManager securityManager;
+    private static boolean securityManagerSupported;
 
     @BeforeClass
     public static void initClass() {
+        securityManagerSupported = MSecurityManager.isSecurityManagerSupported();
+        Assume.assumeTrue(securityManagerSupported);
         executor = Executors.newCachedThreadPool();
         securityManager = new MSecurityManager();
     }
 
     @AfterClass
     public static void doneWithClass() {
-        executor.shutdownNow();
+        if (executor != null) {
+            executor.shutdownNow();
+        }
     }
 
     @Before
     public void initTest() {
+        Assume.assumeTrue(securityManagerSupported);
         securityManager.apply();
         securityManager.goingToExecuteTestCase();
     }
 
     @After
     public void doneWithTestCase() {
+        if (!securityManagerSupported || securityManager == null) {
+            return;
+        }
         securityManager.goingToEndTestCase();
         securityManager.restoreDefaultManager();
     }

--- a/runtime/src/test/java/org/evosuite/runtime/sandbox/SandboxFromJUnitTest.java
+++ b/runtime/src/test/java/org/evosuite/runtime/sandbox/SandboxFromJUnitTest.java
@@ -29,18 +29,26 @@ import java.util.concurrent.TimeUnit;
 public class SandboxFromJUnitTest {
 
     private static ExecutorService executor;
+    private static boolean securityManagerSupported;
 
     @BeforeClass
     public static void initEvoSuiteFramework() {
+        securityManagerSupported = MSecurityManager.isSecurityManagerSupported();
+        Assume.assumeTrue(securityManagerSupported);
         Assert.assertNull(System.getSecurityManager());
 
         Sandbox.initializeSecurityManagerForSUT();
+        Assert.assertEquals(Sandbox.SandboxStatus.LEGACY_ENFORCEMENT, Sandbox.getSandboxStatus());
+        Assert.assertTrue(Sandbox.isEnforcingPermissions());
         executor = Executors.newCachedThreadPool();
 
     }
 
     @AfterClass
     public static void clearEvoSuiteFramework() {
+        if (!securityManagerSupported) {
+            return;
+        }
         Assert.assertNotNull(System.getSecurityManager());
 
         executor.shutdownNow();
@@ -51,13 +59,26 @@ public class SandboxFromJUnitTest {
 
     @Before
     public void initTest() {
+        Assume.assumeTrue(securityManagerSupported);
         Sandbox.goingToExecuteSUTCode();
         //TestGenerationContext.getInstance().goingToExecuteSUTCode();
     }
 
     @After
     public void doneWithTestCase() {
+        if (!securityManagerSupported) {
+            return;
+        }
         Sandbox.doneWithExecutingSUTCode();
+    }
+
+    @Test
+    public void testLegacySandboxStatus() {
+        Assert.assertTrue(Sandbox.isSandboxInitialized());
+        Assert.assertTrue(Sandbox.isEnforcingPermissions());
+        Assert.assertEquals(Sandbox.SandboxStatus.LEGACY_ENFORCEMENT, Sandbox.getSandboxStatus());
+        Assert.assertEquals(Sandbox.EnforcementCapability.LEGACY_SECURITY_MANAGER,
+                Sandbox.getEnforcementCapability());
     }
 
 
@@ -91,5 +112,3 @@ class Foo {
         System.exit(0);
     }
 }
-
-

--- a/runtime/src/test/java/org/evosuite/runtime/sandbox/SandboxStatusTest.java
+++ b/runtime/src/test/java/org/evosuite/runtime/sandbox/SandboxStatusTest.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C) 2010-2018 Gordon Fraser, Andrea Arcuri and EvoSuite
+ * contributors
+ *
+ * This file is part of EvoSuite.
+ *
+ * EvoSuite is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 3.0 of the License, or
+ * (at your option) any later version.
+ *
+ * EvoSuite is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with EvoSuite. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.evosuite.runtime.sandbox;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class SandboxStatusTest {
+
+    @Test
+    public void testStatusReflectsModernJdkDegradedMode() {
+        Assert.assertEquals(Sandbox.SandboxStatus.OFF, Sandbox.getSandboxStatus());
+        Assert.assertEquals(Sandbox.EnforcementCapability.NONE, Sandbox.getEnforcementCapability());
+
+        Sandbox.initializeSecurityManagerForSUT();
+        try {
+            if (MSecurityManager.isSecurityManagerSupported()) {
+                Assert.assertEquals(Sandbox.SandboxStatus.LEGACY_ENFORCEMENT, Sandbox.getSandboxStatus());
+                Assert.assertTrue(Sandbox.isEnforcingPermissions());
+                Assert.assertEquals(Sandbox.EnforcementCapability.LEGACY_SECURITY_MANAGER,
+                        Sandbox.getEnforcementCapability());
+            } else {
+                Assert.assertEquals(Sandbox.SandboxStatus.COORDINATION_ONLY, Sandbox.getSandboxStatus());
+                Assert.assertFalse(Sandbox.isEnforcingPermissions());
+                Assert.assertEquals(Sandbox.EnforcementCapability.NONE, Sandbox.getEnforcementCapability());
+            }
+        } finally {
+            Sandbox.resetDefaultSecurityManager();
+        }
+
+        Assert.assertEquals(Sandbox.SandboxStatus.OFF, Sandbox.getSandboxStatus());
+        Assert.assertEquals(Sandbox.EnforcementCapability.NONE, Sandbox.getEnforcementCapability());
+    }
+}

--- a/runtime/src/test/java/org/evosuite/runtime/util/JavaExecCmdUtilUnixTest.java
+++ b/runtime/src/test/java/org/evosuite/runtime/util/JavaExecCmdUtilUnixTest.java
@@ -22,12 +22,8 @@ package org.evosuite.runtime.util;
 import java.nio.file.Paths;
 import org.apache.commons.lang3.StringUtils;
 import org.hamcrest.core.IsEqual;
-import org.junit.Before;
 import org.junit.FixMethodOrder;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.contrib.java.lang.system.EnvironmentVariables;
-import org.junit.contrib.java.lang.system.RestoreSystemProperties;
 import org.junit.runners.MethodSorters;
 
 import static org.junit.Assert.*;
@@ -41,17 +37,6 @@ public class JavaExecCmdUtilUnixTest {
             SEPARATOR + "usr" + SEPARATOR + "home" + SEPARATOR + "jdk_8";
     private static final String MOCK_OS = "Mac OS X";
 
-    @Rule
-    public EnvironmentVariables environmentVariables = new EnvironmentVariables();
-
-    @Rule
-    public final RestoreSystemProperties restoreSystemProperties = new RestoreSystemProperties();
-
-    @Before
-    public void initTestEnvironment() {
-        environmentVariables.set("JAVA_HOME", JAVA_HOME_MOCK_PATH);
-    }
-
     @Test
     public void unixNeverNull() {
         assertNotNull(JavaExecCmdUtil.getJavaBinExecutablePath());
@@ -61,29 +46,37 @@ public class JavaExecCmdUtilUnixTest {
 
     @Test
     public void unixMockEnvIsOk() {
-        System.setProperty("os.name", MOCK_OS);
-        System.setProperty("file.separator", SEPARATOR);
-        System.setProperty("java.home", JAVA_HOME_MOCK_PATH);
+        String resolved = JavaExecCmdUtil.getJavaBinExecutablePath(
+                JAVA_HOME_MOCK_PATH,
+                MOCK_OS,
+                JAVA_HOME_MOCK_PATH,
+                true
+        );
 
-        assertThat(System.getenv("JAVA_HOME"), IsEqual.equalTo(JAVA_HOME_MOCK_PATH));
-        assertThat(System.getProperty("os.name"), IsEqual.equalTo(MOCK_OS));
+        assertThat(resolved, IsEqual.equalTo(
+                JAVA_HOME_MOCK_PATH + SEPARATOR + "bin" + SEPARATOR + "java"));
         assertFalse(StringUtils.isEmpty(JAVA_HOME_SYSTEM));
     }
 
     @Test
     public void unixOldBehaviorJava() {
         // return "java" value
-        assertThat(JavaExecCmdUtil.getJavaBinExecutablePath(), IsEqual.equalTo("java"));
+        assertThat(JavaExecCmdUtil.getJavaBinExecutablePath(
+                        null,
+                        MOCK_OS,
+                        JAVA_HOME_MOCK_PATH,
+                        false),
+                IsEqual.equalTo("java"));
     }
 
     @Test
     public void unixOldBehaviorJavaCmd() {
-        System.setProperty("os.name", MOCK_OS);
-        System.setProperty("file.separator", SEPARATOR);
-        System.setProperty("java.home", JAVA_HOME_MOCK_PATH);
-
         // return JAVA_CMD value
-        assertThat(JavaExecCmdUtil.getJavaBinExecutablePath(true),
+        assertThat(JavaExecCmdUtil.getJavaBinExecutablePath(
+                        null,
+                        MOCK_OS,
+                        JAVA_HOME_MOCK_PATH,
+                        true),
                 IsEqual.equalTo(
                         JAVA_HOME_MOCK_PATH + SEPARATOR + "bin" + SEPARATOR + "java"));
     }
@@ -94,13 +87,11 @@ public class JavaExecCmdUtilUnixTest {
         JavaExecCmdUtil.getOsName().filter(osName -> !osName.startsWith("Windows"))
                 .ifPresent(os ->
                         {
-                            System.setProperty("os.name", MOCK_OS);
-                            System.setProperty("file.separator", SEPARATOR);
-                            System.setProperty("java.home", JAVA_HOME_MOCK_PATH);
-
-                            // set correct java_home and get real path to java
-                            environmentVariables.set("JAVA_HOME", JAVA_HOME_SYSTEM);
-                            assertThat(JavaExecCmdUtil.getJavaBinExecutablePath(),
+                            assertThat(JavaExecCmdUtil.getJavaBinExecutablePath(
+                                               JAVA_HOME_SYSTEM,
+                                               MOCK_OS,
+                                               JAVA_HOME_MOCK_PATH,
+                                               false),
                                        IsEqual.equalTo(Paths.get(JAVA_HOME_SYSTEM, "bin", "java").toString()));
                         }
                 );

--- a/runtime/src/test/java/org/evosuite/runtime/util/JavaExecCmdUtilWinSystemTest.java
+++ b/runtime/src/test/java/org/evosuite/runtime/util/JavaExecCmdUtilWinSystemTest.java
@@ -23,8 +23,6 @@ import org.apache.commons.lang3.StringUtils;
 import org.hamcrest.core.IsEqual;
 import org.hamcrest.core.StringStartsWith;
 import org.junit.*;
-import org.junit.contrib.java.lang.system.EnvironmentVariables;
-import org.junit.contrib.java.lang.system.ProvideSystemProperty;
 import org.junit.runners.MethodSorters;
 
 import static org.junit.Assert.*;
@@ -39,20 +37,6 @@ public class JavaExecCmdUtilWinSystemTest {
     private static final String WIN_MOCK_OS = "Windows 10";
     private static final String ORIG_OS = System.getProperty("os.name");
 
-    @Rule
-    public EnvironmentVariables environmentVariables = new EnvironmentVariables();
-
-    @Rule
-    public final ProvideSystemProperty properties =
-            new ProvideSystemProperty("os.name", WIN_MOCK_OS)
-                    .and("file.separator", SEPARATOR)
-                    .and("java.home", JAVA_HOME_MOCK_PATH);
-
-    @Before
-    public void initTestEnvironment() {
-        environmentVariables.set("JAVA_HOME", JAVA_HOME_MOCK_PATH);
-    }
-
     @Test
     public void winNeverNull() {
         assertNotNull(JavaExecCmdUtil.getJavaBinExecutablePath());
@@ -65,21 +49,37 @@ public class JavaExecCmdUtilWinSystemTest {
         // run test only on windows build
         Assume.assumeThat(ORIG_OS.toLowerCase(), StringStartsWith.startsWith("win"));
 
-        assertThat(System.getenv("JAVA_HOME"), IsEqual.equalTo(JAVA_HOME_MOCK_PATH));
-        assertThat(System.getProperty("os.name"), IsEqual.equalTo(WIN_MOCK_OS));
+        String resolved = JavaExecCmdUtil.getJavaBinExecutablePath(
+                JAVA_HOME_MOCK_PATH,
+                WIN_MOCK_OS,
+                JAVA_HOME_MOCK_PATH,
+                true
+        );
+
+        assertThat(resolved, IsEqual.equalTo(
+                JAVA_HOME_MOCK_PATH + SEPARATOR + "bin" + SEPARATOR + "java.exe"));
         assertFalse(StringUtils.isEmpty(JAVA_HOME_SYSTEM));
     }
 
     @Test
     public void winOldBehaviorJava() {
         // return "java" value
-        assertThat(JavaExecCmdUtil.getJavaBinExecutablePath(), IsEqual.equalTo("java"));
+        assertThat(JavaExecCmdUtil.getJavaBinExecutablePath(
+                        null,
+                        WIN_MOCK_OS,
+                        JAVA_HOME_MOCK_PATH,
+                        false),
+                IsEqual.equalTo("java"));
     }
 
     @Test
     public void winOldBehaviorJavaCmd() {
         // return JAVA_CMD value
-        assertThat(JavaExecCmdUtil.getJavaBinExecutablePath(true),
+        assertThat(JavaExecCmdUtil.getJavaBinExecutablePath(
+                        null,
+                        WIN_MOCK_OS,
+                        JAVA_HOME_MOCK_PATH,
+                        true),
                 IsEqual.equalTo(
                         JAVA_HOME_MOCK_PATH + SEPARATOR + "bin" + SEPARATOR + "java"));
     }
@@ -91,9 +91,11 @@ public class JavaExecCmdUtilWinSystemTest {
 
         JavaExecCmdUtil.getOsName().filter(osName -> osName.startsWith("Windows")).ifPresent(os ->
                 {
-                    // set correct java_home and get real path to java.exe
-                    environmentVariables.set("JAVA_HOME", JAVA_HOME_SYSTEM);
-                    assertThat(JavaExecCmdUtil.getJavaBinExecutablePath(),
+                    assertThat(JavaExecCmdUtil.getJavaBinExecutablePath(
+                                    JAVA_HOME_SYSTEM,
+                                    WIN_MOCK_OS,
+                                    JAVA_HOME_MOCK_PATH,
+                                    false),
                             IsEqual.equalTo(
                                     JAVA_HOME_SYSTEM + SEPARATOR + "bin" + SEPARATOR + "java.exe"));
                 }


### PR DESCRIPTION
## Summary

This PR modernizes EvoSuite’s compatibility foundation for modern JDKs, with a primary validation target of Java 25.

The goal was not just compilation, but restoring meaningful runtime, client, master, and plugin behavior on a modern JDK while making degraded behavior explicit where legacy `SecurityManager` assumptions no longer hold.

## What Changed

- modernized runtime compatibility for newer JDKs
- reduced reliance on forbidden JDK-internal reflection in networking and URL-related paths
- improved GUI/headless handling on strongly encapsulated JDKs
- restored key symbolic and concolic client test flows on Java 25
- upgraded Maven Surefire/Failsafe support for modern test execution
- updated master generation paths and CTG startup behavior for Java 25
- introduced clearer sandbox capability reporting and explicit coordination-only behavior on modern JDKs
- restored focused Maven plugin and build-support verification flows
- reduced warning noise on Java 25, including CTG timezone startup warnings and spawn-process shutdown noise
- fixed generated scaffolding imports for `@AfterClass`

## Key Areas

### Runtime
- modernized reflective fallback behavior in runtime network and URL support
- improved modern-JDK-safe handling for GUI/headless and class reset behavior
- updated date/calendar mock locale accessors to use more direct JDK APIs

### Client
- restored focused symbolic/concolic paths on Java 25
- improved generated scaffolding imports so generated tests compile correctly
- kept separate-process JUnit verification support working on modern JDKs

### Master
- improved CTG startup compatibility and reduced warning noise
- cleaned up spawn-process output handling so normal shutdown no longer logs stream-closed noise
- replaced the deprecated commons-lang timestamp path in CTG temp-folder naming with `java.time`

### Sandbox
- made modern-JDK sandbox behavior explicit instead of implicitly failing
- separated capability reporting from legacy `SecurityManager` enforcement expectations
- kept compatibility while documenting coordination-only behavior where real enforcement is unavailable

### Plugins
- restored focused Maven plugin and build-support verification on modern JDKs
- aligned test/plugin infrastructure with the updated execution model

## Validation

Validated on Java 25 with focused checks across:
- `runtime`
- `client`
- `master`
- `plugins/maven-test`
- `plugins/build-support-test`

Also validated with end-to-end smoke generation/export/test execution on a small sample project.

## Notes

Remaining warnings that may still appear are largely outside direct EvoSuite control or reflect honest modern-JDK capability limits, for example:
- Maven/Guice `sun.misc.Unsafe` warning from the local Maven stack
- capability warnings around sandbox enforcement or deep AWT/network reflection on strongly encapsulated JDKs

These are not regressions in the core modernization work and do not block the validated Java 25 foundation milestone.
